### PR TITLE
Some noodling to support the anysphere extension in cursor (clangd)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ recordings/
 dist/
 logs/
 noobs-*.tgz
+src/.cache
+src/compile_commands.json
+bin/win32-x64-116

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "node": ">=14.0.0"
   },
   "scripts": {
-    "build": "node-gyp rebuild && node dist.js"
+    "build": "node-gyp rebuild && node dist.js",
+    "configure-cursor-anysphere": "node-gyp configure -- -f compile_commands_json && copy build\\Release\\compile_commands.json src\\compile_commands.json"
   },
   "files": [
     "index.js",

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -437,6 +437,7 @@ Napi::Value ObsSetDrawSourceOutline(const Napi::CallbackInfo& info) {
   bool enabled = info[0].As<Napi::Boolean>();
   blog(LOG_DEBUG, "ObsSetDrawSourceOutline set to %d", enabled);
   obs->setDrawSourceOutline(enabled);
+  return info.Env().Undefined();
 }
 
 Napi::Value ObsGetDrawSourceOutlineEnabled(const Napi::CallbackInfo& info) {

--- a/src/obs_interface.cpp
+++ b/src/obs_interface.cpp
@@ -1,13 +1,8 @@
-#include <iostream>
 #include <windows.h>
 #include <obs.h>
 #include "utils.h"
-#include <chrono>
 #include "obs_interface.h"
 #include <vector>
-#include <thread>
-#include <iostream>
-#include <map>
 #include <string>
 #include <graphics/matrix4.h>
 #include <graphics/vec4.h>
@@ -1004,12 +999,12 @@ void ObsInterface::getSourcePos(std::string name, vec2* pos, vec2* size, vec2* s
   obs_sceneitem_t *item = obs_scene_find_source(scene, name.c_str());
 
   if (!src) {
-    blog(LOG_WARNING, "Did not find source for video source: %s", name);
+    blog(LOG_WARNING, "Did not find source for video source: %s", name.c_str());
     return;
   }
 
   if (!item) {
-    blog(LOG_WARNING, "Did not find scene item for video source: %s", name);
+    blog(LOG_WARNING, "Did not find scene item for video source: %s", name.c_str());
     return;
   }
 
@@ -1025,7 +1020,7 @@ void ObsInterface::setSourcePos(std::string name, vec2* pos, vec2* scale) {
   obs_sceneitem_t *item = obs_scene_find_source(scene, name.c_str());
 
   if (!item) {
-    blog(LOG_WARNING, "Did not find scene item for video source: %s", name);
+    blog(LOG_WARNING, "Did not find scene item for video source: %s", name.c_str());
     return;
   }
 

--- a/src/obs_interface.h
+++ b/src/obs_interface.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <obs.h>
 #include <napi.h>
+#include <windows.h>
 
 struct SignalData {
   std::string id;


### PR DESCRIPTION
Cursor users can run `configure-cursor-anysphere` to write the compile commands to a json file (similar to c_cpp_properties.json) to make sure the language server will include the correct headers. This approach might be useful for the c_cpp_properties file as well but I haven't investigated if gyp will autowrite that just yet.

clangd is a bit stricter than gcc/msc which caused some trivial changes which I will note with comments on this PR