### PR TITLE
Add Linux support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,7 @@ noobs-*.tgz
 src/.cache
 src/compile_commands.json
 bin/win32-x64-116
+bin/linux-x64-139/
 win-capture/
+claude.md
+noobs.node

--- a/LINUX_DEPENDENCIES.md
+++ b/LINUX_DEPENDENCIES.md
@@ -1,0 +1,266 @@
+# Linux Dependencies for WoW Recorder
+
+This document outlines the dependencies required to run WoW Recorder on various Linux distributions.
+
+## Required Dependencies
+
+### Core OBS Libraries
+
+| Package | Fedora | Ubuntu/Debian | Arch Linux | openSUSE |
+|---------|--------|---------------|------------|----------|
+| libobs | `obs-studio` | `libobs-dev`, `obs-studio` | `obs-studio` | `obs-studio` |
+| obs-ffmpeg-mux | included in `obs-studio` | included in `obs-studio` | included in `obs-studio` | included in `obs-studio` |
+
+### Audio Encoding (FDK-AAC)
+
+| Distribution | Package Name | Repository |
+|--------------|--------------|------------|
+| Fedora | `fdk-aac-free` | RPM Fusion Free |
+| Ubuntu | `libfdk-aac2`, `libfdk-aac-dev` | Universe |
+| Debian | `libfdk-aac2`, `libfdk-aac-dev` | Non-free (Bookworm+) |
+| Arch Linux | `libfdk-aac` | Extra |
+| openSUSE | `fdk-aac-free` | Packman |
+
+### PulseAudio/PipeWire
+
+| Distribution | Package Name |
+|--------------|--------------|
+| Fedora | `pipewire-pulseaudio` (default), `pulseaudio` |
+| Ubuntu/Debian | `pipewire` or `pulseaudio` |
+| Arch Linux | `pipewire-pulse` or `pulseaudio` |
+| openSUSE | `pipewire` or `pulseaudio` |
+
+### Build Dependencies (for noobs-linux)
+
+| Package | Fedora | Ubuntu/Debian | Arch Linux | openSUSE |
+|---------|--------|---------------|------------|----------|
+| Node.js | `nodejs` | `nodejs` | `nodejs` | `nodejs18` |
+| npm | `npm` | `npm` | `npm` | `npm18` |
+| node-gyp | `npm install -g node-gyp` | `npm install -g node-gyp` | `npm install -g node-gyp` | `npm install -g node-gyp` |
+| C++ compiler | `gcc-c++` | `build-essential` | `base-devel` | `gcc-c++` |
+| CMake | `cmake` | `cmake` | `cmake` | `cmake` |
+
+## File Locations
+
+### obs-ffmpeg-mux Location
+
+| Distribution | Path |
+|--------------|------|
+| Fedora | `/usr/bin/obs-ffmpeg-mux` |
+| Ubuntu/Debian | `/usr/lib/x86_64-linux-gnu/obs-plugins/obs-ffmpeg/obs-ffmpeg-mux` |
+| Arch Linux | `/usr/bin/obs-ffmpeg-mux` |
+| openSUSE | `/usr/bin/obs-ffmpeg-mux` |
+
+**Note:** On Ubuntu/Debian, the muxer is in a non-standard location. The application attempts to find it automatically, but you may need to create a symlink:
+
+```bash
+# Ubuntu/Debian only - if muxer not found automatically
+sudo ln -sf /usr/lib/x86_64-linux-gnu/obs-plugins/obs-ffmpeg/obs-ffmpeg-mux /usr/bin/obs-ffmpeg-mux
+```
+
+### OBS Plugin Paths
+
+| Distribution | Path |
+|--------------|------|
+| Fedora | `/usr/lib64/obs-plugins/` |
+| Ubuntu/Debian (x86_64) | `/usr/lib/x86_64-linux-gnu/obs-plugins/` |
+| Arch Linux | `/usr/lib/obs-plugins/` |
+| openSUSE | `/usr/lib64/obs-plugins/` |
+
+### OBS Data Path
+
+| Distribution | Path |
+|--------------|------|
+| Fedora | `/usr/share/obs/` |
+| Ubuntu/Debian | `/usr/share/obs/` |
+| Arch Linux | `/usr/share/obs/` |
+| openSUSE | `/usr/share/obs/` |
+
+## Installation Instructions
+
+### Fedora
+
+```bash
+# Enable RPM Fusion (if not already enabled)
+sudo dnf install https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm
+
+# Install dependencies
+sudo dnf install obs-studio fdk-aac-free pipewire-pulseaudio
+
+# Build dependencies (for development)
+sudo dnf install nodejs npm gcc-c++ cmake obs-studio-devel
+```
+
+### Ubuntu / Linux Mint
+
+```bash
+# Ubuntu 22.04+ / Linux Mint 21+
+sudo apt update
+sudo apt install obs-studio libfdk-aac2 libfdk-aac-dev pipewire
+
+# Build dependencies (for development)
+sudo apt install nodejs npm build-essential cmake libobs-dev
+
+# Create symlink for obs-ffmpeg-mux (if needed)
+if [ -f /usr/lib/x86_64-linux-gnu/obs-plugins/obs-ffmpeg/obs-ffmpeg-mux ]; then
+    sudo ln -sf /usr/lib/x86_64-linux-gnu/obs-plugins/obs-ffmpeg/obs-ffmpeg-mux /usr/bin/obs-ffmpeg-mux
+fi
+```
+
+### Debian
+
+```bash
+# Debian 12 (Bookworm) and later
+# Enable non-free repository for FDK-AAC
+sudo apt edit-sources
+# Add "non-free" to end of your deb lines
+
+sudo apt update
+sudo apt install obs-studio libfdk-aac2 libfdk-aac-dev pipewire
+
+# Build dependencies (for development)
+sudo apt install nodejs npm build-essential cmake libobs-dev
+
+# Create symlink for obs-ffmpeg-mux (if needed)
+if [ -f /usr/lib/x86_64-linux-gnu/obs-plugins/obs-ffmpeg/obs-ffmpeg-mux ]; then
+    sudo ln -sf /usr/lib/x86_64-linux-gnu/obs-plugins/obs-ffmpeg/obs-ffmpeg-mux /usr/bin/obs-ffmpeg-mux
+fi
+```
+
+### Arch Linux / Manjaro
+
+```bash
+# Install dependencies
+sudo pacman -S obs-studio libfdk-aac pipewire-pulse
+
+# Build dependencies (for development)
+sudo pacman -S nodejs npm base-devel cmake
+```
+
+### openSUSE
+
+```bash
+# Enable Packman repository for FDK-AAC
+sudo zypper ar -cfp 90 'https://ftp.gwdg.de/pub/linux/misc/packman/suse/openSUSE_Tumbleweed/' packman
+
+# Install dependencies
+sudo zypper install obs-studio fdk-aac-free pipewire
+
+# Build dependencies (for development)
+sudo zypper install nodejs18 npm18 gcc-c++ cmake obs-studio-devel
+```
+
+## Troubleshooting
+
+### No Audio in Recordings
+
+1. **Check FDK-AAC is installed:**
+   ```bash
+   # Look for the obs-libfdk module
+   find /usr -name "*libfdk*" 2>/dev/null
+   ```
+
+2. **Check audio devices:**
+   ```bash
+   # List PulseAudio/PipeWire sources
+   pactl list sources short
+   ```
+
+3. **Verify OBS can access audio:**
+   - Open regular OBS Studio
+   - Add an audio source
+   - If it works there, it should work in WoW Recorder
+
+### "Failed to create process pipe" Error
+
+This means `obs-ffmpeg-mux` wasn't found. Solutions:
+
+1. **Find the muxer:**
+   ```bash
+   find /usr -name "obs-ffmpeg-mux" 2>/dev/null
+   ```
+
+2. **Create symlink to `/usr/bin/`:**
+   ```bash
+   sudo ln -sf /path/to/obs-ffmpeg-mux /usr/bin/obs-ffmpeg-mux
+   ```
+
+### Video Recording Works but No File Saved
+
+1. Check that the storage path exists and is writable
+2. Check logs for errors during the save operation
+3. Ensure sufficient disk space
+
+### Screen Capture Not Working (Wayland)
+
+On Wayland, screen capture requires PipeWire. Install it:
+
+```bash
+# Fedora
+sudo dnf install pipewire
+
+# Ubuntu/Debian
+sudo apt install pipewire
+
+# Arch
+sudo pacman -S pipewire
+```
+
+You may need to grant screen sharing permissions through your desktop environment's settings.
+
+## Hardware Acceleration
+
+### NVIDIA (NVENC)
+
+```bash
+# Fedora
+sudo dnf install nvidia-driver cuda
+
+# Ubuntu
+sudo apt install nvidia-driver-xxx  # Replace xxx with version
+
+# Arch
+sudo pacman -S nvidia nvidia-utils cuda
+```
+
+### AMD (VAAPI)
+
+```bash
+# Fedora
+sudo dnf install mesa-va-drivers libva-utils
+
+# Ubuntu
+sudo apt install mesa-va-drivers vainfo
+
+# Arch
+sudo pacman -S libva-mesa-driver libva-utils
+```
+
+### Intel (QSV/VAAPI)
+
+```bash
+# Fedora
+sudo dnf install intel-media-driver libva-utils
+
+# Ubuntu
+sudo apt install intel-media-va-driver vainfo
+
+# Arch
+sudo pacman -S intel-media-driver libva-utils
+```
+
+## Verified Working Configurations
+
+| Distribution | Version | Desktop | Status |
+|--------------|---------|---------|--------|
+| Fedora | 43 | GNOME (Wayland) | ✅ Working |
+| Ubuntu | 24.04 | GNOME | 🔄 Untested |
+| Arch Linux | Rolling | Various | 🔄 Untested |
+| Debian | 12 | GNOME | 🔄 Untested |
+| openSUSE | Tumbleweed | KDE | 🔄 Untested |
+
+## Notes
+
+- **Wayland vs X11:** PipeWire screen capture works on both Wayland and X11. X11 capture (`linux-capture` module) only works on X11.
+- **Flatpak OBS:** If using Flatpak version of OBS Studio, paths will be different (`~/.var/app/com.obsproject.Studio/...`). The Flatpak version is NOT recommended for WoW Recorder.
+- **Wine/Proton:** WoW runs via Wine/Proton (Lutris, Heroic, Steam). Make sure your Wine prefix logs are accessible at the configured path.

--- a/LINUX_PACKAGING.md
+++ b/LINUX_PACKAGING.md
@@ -1,0 +1,296 @@
+# Linux Packaging Guide for WoW Recorder
+
+This document describes how to build and package WoW Recorder for Linux distribution.
+
+## Build Architecture
+
+WoW Recorder consists of two main components:
+
+1. **noobs-linux**: Native Node.js module that interfaces with OBS (libobs)
+2. **wow-recorder**: Electron application that uses noobs-linux
+
+## Prerequisites
+
+### Build Dependencies
+
+```bash
+# Fedora
+sudo dnf install nodejs npm gcc-c++ cmake obs-studio-devel fdk-aac-free-devel
+
+# Ubuntu/Debian
+sudo apt install nodejs npm build-essential cmake libobs-dev libfdk-aac-dev
+
+# Arch Linux
+sudo pacman -S nodejs npm base-devel cmake obs-studio libfdk-aac
+```
+
+### Runtime Dependencies
+
+Users must have these installed:
+- `obs-studio` (provides libobs, obs-ffmpeg-mux, and OBS plugins)
+- `fdk-aac-free` or `libfdk-aac` (for AAC audio encoding)
+- `pipewire` or `pulseaudio` (for audio capture)
+
+## Building
+
+### 1. Build noobs-linux
+
+```bash
+cd noobs-linux
+npm install
+npm run rebuild
+```
+
+This compiles the native module (`noobs.node`) which links against libobs.
+
+### 2. Install wow-recorder dependencies
+
+```bash
+cd wow-recorder
+npm install
+cd release/app
+npm install
+cd ../..
+```
+
+The `release/app/package.json` references noobs-linux via `file:../../../noobs-linux`.
+
+### 3. Build the Electron app
+
+```bash
+cd wow-recorder
+npm run build
+```
+
+## Packaging
+
+### Using electron-builder
+
+The project is configured to produce AppImage, deb, and rpm packages:
+
+```bash
+cd wow-recorder
+npm run package
+```
+
+Or build specific formats:
+
+```bash
+# AppImage only
+npx electron-builder --linux AppImage
+
+# Debian package only
+npx electron-builder --linux deb
+
+# RPM only
+npx electron-builder --linux rpm
+```
+
+Output files are placed in `wow-recorder/release/build/`.
+
+### Package Configuration
+
+The `build` section in `wow-recorder/package.json` configures packaging:
+
+```json
+{
+  "build": {
+    "linux": {
+      "artifactName": "WarcraftRecorder-${version}-${arch}.${ext}",
+      "target": ["AppImage", "deb", "rpm"],
+      "category": "Game;Utility",
+      "maintainer": "Warcraft Recorder"
+    }
+  }
+}
+```
+
+## AppImage Specifics
+
+### Bundled vs System Dependencies
+
+The AppImage bundles the Electron runtime and the application code, but it does **NOT** bundle system OBS libraries. Users must have OBS Studio installed on their system.
+
+This is by design because:
+1. OBS libraries are large and frequently updated
+2. System OBS plugins (like obs-pipewire) integrate with the desktop
+3. Hardware encoders require matching system drivers
+
+### Runtime Detection
+
+The application automatically:
+1. Searches for `obs-ffmpeg-mux` in known system paths
+2. Creates a symlink if needed for the replay buffer to work
+3. Falls back gracefully if audio encoders aren't available
+
+### Known Issues with AppImage
+
+1. **PipeWire Portal**: The first run may not show the screen capture dialog. Users may need to restart the app after the first launch.
+
+2. **Sandbox Permissions**: AppImage sandboxing may interfere with screen capture. If capture doesn't work, try running with `--no-sandbox` flag.
+
+3. **Audio Device Detection**: PulseAudio/PipeWire devices are detected at runtime. The app may need to be restarted after connecting new audio devices.
+
+## Distribution-Specific Packages
+
+### Debian/Ubuntu (.deb)
+
+The deb package declares runtime dependencies:
+
+```bash
+# Add dependencies to electron-builder config if needed:
+"deb": {
+  "depends": [
+    "obs-studio",
+    "libfdk-aac2",
+    "pipewire"
+  ]
+}
+```
+
+### Fedora/RHEL (.rpm)
+
+```bash
+# RPM dependencies:
+"rpm": {
+  "depends": [
+    "obs-studio",
+    "fdk-aac-free",
+    "pipewire"
+  ]
+}
+```
+
+### Arch Linux (PKGBUILD)
+
+For AUR packaging, create a PKGBUILD:
+
+```bash
+pkgname=warcraft-recorder
+pkgver=7.3.0
+pkgrel=1
+pkgdesc="Record your World of Warcraft encounters"
+arch=('x86_64')
+url="https://www.warcraftrecorder.com/"
+license=('custom:CC-BY-NC')
+depends=('obs-studio' 'libfdk-aac' 'pipewire-pulse')
+makedepends=('nodejs' 'npm' 'cmake')
+source=("$pkgname-$pkgver.tar.gz::https://github.com/aza547/wow-recorder/archive/v$pkgver.tar.gz")
+```
+
+## Testing the Package
+
+### AppImage Testing
+
+```bash
+# Make executable
+chmod +x WarcraftRecorder-7.3.0-x86_64.AppImage
+
+# Run
+./WarcraftRecorder-7.3.0-x86_64.AppImage
+
+# Run with verbose logging
+./WarcraftRecorder-7.3.0-x86_64.AppImage --enable-logging
+
+# Run without sandbox (if screen capture fails)
+./WarcraftRecorder-7.3.0-x86_64.AppImage --no-sandbox
+```
+
+### Verify Native Module
+
+The native module should be in the unpacked asar:
+
+```bash
+# For development/testing
+ls -la wow-recorder/release/app/node_modules/noobs/
+
+# For packaged app, extract and check
+./WarcraftRecorder-*.AppImage --appimage-extract
+ls -la squashfs-root/resources/app.asar.unpacked/node_modules/noobs/
+```
+
+## Troubleshooting
+
+### "Cannot find module 'noobs'"
+
+The native module wasn't properly built or packaged. Rebuild:
+
+```bash
+cd noobs-linux
+npm run rebuild
+cd ../wow-recorder/release/app
+npm rebuild
+```
+
+### "Failed to create process pipe"
+
+OBS can't find `obs-ffmpeg-mux`. The app should auto-detect it, but you can manually check:
+
+```bash
+# Verify obs-ffmpeg-mux exists
+which obs-ffmpeg-mux || find /usr -name "obs-ffmpeg-mux" 2>/dev/null
+```
+
+### Screen capture not working
+
+1. Ensure PipeWire is running: `systemctl --user status pipewire`
+2. Grant screen sharing permission in your desktop settings
+3. Try running with `--no-sandbox` flag
+
+### No audio in recordings
+
+1. Check FDK-AAC is installed: `find /usr -name "*libfdk*" 2>/dev/null`
+2. Verify audio devices in settings
+3. Check OBS can record audio independently
+
+## Continuous Integration
+
+For automated builds, you'll need:
+
+```yaml
+# GitHub Actions example
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libobs-dev libfdk-aac-dev
+
+      - name: Build noobs-linux
+        run: |
+          cd noobs-linux
+          npm install
+          npm run rebuild
+
+      - name: Build and package
+        run: |
+          cd wow-recorder
+          npm install
+          npm run package
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-packages
+          path: wow-recorder/release/build/*.{AppImage,deb,rpm}
+```
+
+## Version Compatibility
+
+| Component | Minimum Version | Notes |
+|-----------|-----------------|-------|
+| Node.js | 18.x | Required for native module build |
+| Electron | 28.x | For PipeWire support |
+| OBS Studio | 30.0 | For libobs compatibility |
+| libobs | 30.0 | API compatibility |
+
+## Architecture Support
+
+Currently only **x86_64** is supported. ARM64 support would require:
+1. Building noobs.node for ARM64
+2. Ensuring OBS ARM64 packages are available
+3. Testing hardware encoder support (VAAPI)

--- a/TESTING_CHECKLIST.md
+++ b/TESTING_CHECKLIST.md
@@ -1,0 +1,201 @@
+# Linux Testing Checklist for WoW Recorder
+
+## Test Environment
+
+- [ ] **OS**: Fedora 43
+- [ ] **Desktop**: GNOME (Wayland)
+- [ ] **WoW Version**: Retail via Heroic Launcher
+- [ ] **OBS Version**: (run `obs --version`)
+- [ ] **Audio System**: PipeWire
+
+---
+
+## 1. Application Startup
+
+### 1.1 Clean Start
+- [ ] App launches without errors
+- [ ] No crash on startup
+- [ ] UI displays correctly
+- [ ] Tray icon appears
+
+### 1.2 OBS Initialization
+Check logs for:
+- [ ] `[Recorder] OBS initialized successfully`
+- [ ] No `obs-ffmpeg-mux` errors
+- [ ] Audio encoder created (look for `FDK-AAC` or `AAC`)
+
+### 1.3 PipeWire Screen Capture
+- [ ] PipeWire portal dialog appears when configuring capture
+- [ ] Can select WoW window
+- [ ] Preview shows capture source
+
+---
+
+## 2. Audio Configuration
+
+### 2.1 Audio Device Detection
+- [ ] Output devices (speakers/headphones) detected
+- [ ] Input devices (microphone) detected
+- [ ] Volume meters respond to audio
+
+### 2.2 Audio Recording
+- [ ] Game audio recorded in video
+- [ ] Microphone audio recorded (if enabled)
+- [ ] No audio distortion or choppy audio
+- [ ] Audio sync with video
+
+---
+
+## 3. Recording Tests
+
+### 3.1 Raid Encounter Recording
+- [ ] Pull a raid boss
+- [ ] Recording starts automatically on `ENCOUNTER_START`
+- [ ] Recording continues during fight
+- [ ] Recording stops on `ENCOUNTER_END`
+- [ ] Video saved with correct metadata
+
+Verify in video:
+- [ ] ~15 seconds pre-roll before pull
+- [ ] Entire fight captured
+- [ ] ~15 seconds overrun after kill
+- [ ] Audio present and synced
+
+### 3.2 Mythic+ Dungeon Recording
+- [ ] Start a M+ key
+- [ ] Recording starts on timer begin
+- [ ] Recording continues through dungeon
+- [ ] Recording stops on completion/abandon
+
+### 3.3 Manual Recording (if enabled)
+- [ ] Hotkey starts recording
+- [ ] Hotkey stops recording
+- [ ] Sound alerts play (if enabled)
+
+---
+
+## 4. Video Processing
+
+### 4.1 Post-Processing
+- [ ] Video queued for processing after recording
+- [ ] FFmpeg processes without errors
+- [ ] MKV converted to MP4
+- [ ] Video appears in library
+
+### 4.2 Video Playback
+- [ ] Video plays in app
+- [ ] Seeking works correctly
+- [ ] Audio plays
+- [ ] Death markers (if applicable) display at correct times
+
+### 4.3 Video Metadata
+- [ ] Encounter name correct
+- [ ] Duration correct
+- [ ] Result (kill/wipe) correct
+- [ ] Player name captured
+
+---
+
+## 5. Edge Cases
+
+### 5.1 Quick Wipe and Repull
+- [ ] Wipe on boss
+- [ ] First video saved correctly
+- [ ] Repull immediately
+- [ ] Second video saved correctly
+- [ ] Both videos distinct
+
+### 5.2 Long Fight
+- [ ] Fight longer than 10 minutes
+- [ ] Entire fight recorded
+- [ ] No buffer issues
+- [ ] Audio remains synced
+
+### 5.3 App Backgrounded
+- [ ] Minimize app
+- [ ] Recording continues normally
+- [ ] Bring app back to foreground
+- [ ] Recording still works
+
+### 5.4 WoW Client Restart
+- [ ] Close WoW
+- [ ] Buffer stops (check logs)
+- [ ] Reopen WoW
+- [ ] Buffer restarts
+- [ ] New recording works
+
+---
+
+## 6. Error Handling
+
+### 6.1 Missing Audio Encoder
+- [ ] If FDK-AAC not installed, app logs warning
+- [ ] Recording continues (video-only)
+
+### 6.2 Screen Capture Permission Denied
+- [ ] App shows appropriate error/guidance
+- [ ] Can retry capture selection
+
+### 6.3 Disk Space
+- [ ] Low disk space warning (if applicable)
+
+---
+
+## 7. Performance
+
+### 7.1 Resource Usage
+During recording:
+- [ ] CPU usage reasonable (<20% when idle)
+- [ ] Memory usage stable (not growing)
+- [ ] GPU encoder used (check logs for encoder type)
+
+### 7.2 Game Performance
+- [ ] No noticeable FPS drop in WoW while recording
+- [ ] No audio crackling or stuttering
+
+---
+
+## Test Results Log
+
+| Test | Pass/Fail | Notes |
+|------|-----------|-------|
+| 1.1 Clean Start | | |
+| 1.2 OBS Init | | |
+| 1.3 PipeWire | | |
+| 2.1 Audio Devices | | |
+| 2.2 Audio Recording | | |
+| 3.1 Raid Recording | | |
+| 3.2 M+ Recording | | |
+| 4.1 Post-Processing | | |
+| 4.2 Video Playback | | |
+| 5.1 Quick Repull | | |
+| 5.2 Long Fight | | |
+
+---
+
+## How to Run Tests
+
+1. **Start the app in development mode:**
+   ```bash
+   cd wow-recorder
+   npm run start
+   ```
+
+2. **Check logs in real-time:**
+   The logs appear in the terminal where you started the app.
+
+3. **Check log files:**
+   ```bash
+   cat ~/.config/WarcraftRecorder/logs/WarcraftRecorder-$(date +%Y-%m-%d).log
+   ```
+
+4. **Verify recordings:**
+   Default storage path: `~/WarcraftRecorder/`
+
+---
+
+## Known Issues to Watch For
+
+1. **Audio choppy on first recording**: May need to restart app after initial setup
+2. **Buffer size warning**: Large buffer (20 min) may show warnings, can be ignored
+3. **PipeWire dialog not appearing**: Restart app if capture source not selectable

--- a/binding.gyp
+++ b/binding.gyp
@@ -12,12 +12,36 @@
             "<!@(node -p \"require('node-addon-api').include\")",
             "include"
         ],
-        'libraries': [
-            "../bin/64bit/obs.lib",
-        ],
         'dependencies': [
             "<!(node -p \"require('node-addon-api').gyp\")"
         ],
         'defines': [ 'NAPI_DISABLE_CPP_EXCEPTIONS' ],
+        'conditions': [
+            ['OS=="win"', {
+                'libraries': [
+                    "../bin/64bit/obs.lib",
+                ],
+            }],
+            ['OS=="linux"', {
+                'include_dirs': [
+                    "/usr/include/obs"
+                ],
+                'libraries': [
+                    "-lobs",
+                    "-lobs-frontend-api",
+                    "-lX11"
+                ],
+                'cflags': [
+                    "-fPIC"
+                ],
+                'cflags_cc': [
+                    "-fPIC",
+                    "-std=c++17"
+                ],
+                'defines': [
+                    "__linux__"
+                ]
+            }]
+        ]
     }]
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,13 +1,16 @@
 #include <napi.h>
-#include <windows.h>
 #include <obs.h>
 #include "obs_interface.h"
 #include "utils.h"
 
-ObsInterface* obs = nullptr;
-
+#ifdef _WIN32
+#include <windows.h>
+// GPU preference exports for Windows
 extern "C" __declspec(dllexport) DWORD NvOptimusEnablement = 1;
 extern "C" __declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
+#endif
+
+ObsInterface* obs = nullptr;
 
 Napi::Value ObsInit(const Napi::CallbackInfo& info) {
   bool valid = info.Length() == 3 &&
@@ -156,6 +159,38 @@ Napi::Value ObsSetBuffering(const Napi::CallbackInfo& info) {
   return info.Env().Undefined();
 }
 
+// Async worker for starting buffer on Linux to prevent blocking
+class StartBufferWorker : public Napi::AsyncWorker {
+public:
+  StartBufferWorker(Napi::Function& callback)
+    : Napi::AsyncWorker(callback), success(false) {}
+
+  void Execute() override {
+    try {
+      blog(LOG_INFO, "StartBufferWorker: Execute starting");
+      obs->startBuffering();
+      success = true;
+      blog(LOG_INFO, "StartBufferWorker: Execute completed successfully");
+    } catch (const std::exception& e) {
+      blog(LOG_ERROR, "StartBufferWorker: Exception: %s", e.what());
+      SetError(e.what());
+    }
+  }
+
+  void OnOK() override {
+    blog(LOG_INFO, "StartBufferWorker: OnOK called");
+    Callback().Call({Env().Null()});
+  }
+
+  void OnError(const Napi::Error& e) override {
+    blog(LOG_ERROR, "StartBufferWorker: OnError called: %s", e.Message().c_str());
+    Callback().Call({Napi::String::New(Env(), e.Message())});
+  }
+
+private:
+  bool success;
+};
+
 Napi::Value ObsStartBuffer(const Napi::CallbackInfo& info) {
   blog(LOG_INFO, "ObsStartBuffer called");
 
@@ -165,6 +200,18 @@ Napi::Value ObsStartBuffer(const Napi::CallbackInfo& info) {
     return info.Env().Undefined();
   }
 
+#ifdef __linux__
+  // On Linux, run async to prevent blocking (obs_output_start can hang)
+  if (info.Length() >= 1 && info[0].IsFunction()) {
+    blog(LOG_INFO, "ObsStartBuffer: Using async mode on Linux");
+    Napi::Function callback = info[0].As<Napi::Function>();
+    StartBufferWorker* worker = new StartBufferWorker(callback);
+    worker->Queue();
+    return info.Env().Undefined();
+  }
+#endif
+
+  // Synchronous mode (Windows or no callback provided)
   obs->startBuffering();
   return info.Env().Undefined();
 }
@@ -228,6 +275,7 @@ Napi::Value ObsInitPreview(const Napi::CallbackInfo& info) {
     return info.Env().Undefined();
   }
 
+#ifdef _WIN32
   bool valid = info.Length() == 1 && info[0].IsBuffer();
 
   if (!valid) {
@@ -237,13 +285,34 @@ Napi::Value ObsInitPreview(const Napi::CallbackInfo& info) {
 
   Napi::Buffer<uint8_t> buffer = info[0].As<Napi::Buffer<uint8_t>>();
 
-  if (buffer.Length() < sizeof(HWND)) {
-    Napi::TypeError::New(info.Env(), "Buffer too small for HWND").ThrowAsJavaScriptException();
+  if (buffer.Length() < sizeof(NativeWindowHandle)) {
+    Napi::TypeError::New(info.Env(), "Buffer too small for window handle").ThrowAsJavaScriptException();
     return info.Env().Undefined();
   }
 
-  HWND hwnd = *reinterpret_cast<HWND*>(buffer.Data());
+  NativeWindowHandle hwnd = *reinterpret_cast<NativeWindowHandle*>(buffer.Data());
   obs->initPreview(hwnd);
+#else
+  // Linux: Extract X11 Window ID from Electron's getNativeWindowHandle()
+  bool valid = info.Length() == 1 && info[0].IsBuffer();
+
+  if (!valid) {
+    Napi::TypeError::New(info.Env(), "Invalid arguments passed to ObsInitPreview").ThrowAsJavaScriptException();
+    return info.Env().Undefined();
+  }
+
+  Napi::Buffer<uint8_t> buffer = info[0].As<Napi::Buffer<uint8_t>>();
+
+  if (buffer.Length() < sizeof(NativeWindowHandle)) {
+    Napi::TypeError::New(info.Env(), "Buffer too small for window handle").ThrowAsJavaScriptException();
+    return info.Env().Undefined();
+  }
+
+  // On Linux, Electron returns the X11 Window ID as a 32-bit unsigned int
+  NativeWindowHandle x11_window_id = *reinterpret_cast<NativeWindowHandle*>(buffer.Data());
+  blog(LOG_INFO, "Received X11 Window ID: %u", x11_window_id);
+  obs->initPreview(x11_window_id);
+#endif
   return info.Env().Undefined();
 }
 
@@ -441,6 +510,29 @@ Napi::Value ObsGetSourceProperties(const Napi::CallbackInfo& info) {
   return result;
 }
 
+Napi::Value ObsGetSourceDimensions(const Napi::CallbackInfo& info) {
+  if (!obs) {
+    blog(LOG_ERROR, "ObsGetSourceDimensions called but obs is not initialized");
+    Napi::Error::New(info.Env(), "Obs not initialized").ThrowAsJavaScriptException();
+    return info.Env().Undefined();
+  }
+
+  bool valid = info.Length() == 1 && info[0].IsString();
+
+  if (!valid) {
+    Napi::TypeError::New(info.Env(), "Invalid arguments passed to ObsGetSourceDimensions").ThrowAsJavaScriptException();
+    return info.Env().Undefined();
+  }
+
+  std::string name = info[0].As<Napi::String>().Utf8Value();
+  SourceSize size = obs->getSourceDimensions(name);
+
+  Napi::Object result = Napi::Object::New(info.Env());
+  result.Set("width", Napi::Number::New(info.Env(), size.width));
+  result.Set("height", Napi::Number::New(info.Env(), size.height));
+
+  return result;
+}
 
 Napi::Value ObsSetMuteAudioInputs(const Napi::CallbackInfo& info) {
   if (!obs) {
@@ -689,6 +781,7 @@ Napi::Object Init(Napi::Env env, Napi::Object exports) {
   exports.Set("GetSourceSettings", Napi::Function::New(env, ObsGetSourceSettings));
   exports.Set("SetSourceSettings", Napi::Function::New(env, ObsSetSourceSettings));
   exports.Set("GetSourceProperties", Napi::Function::New(env, ObsGetSourceProperties));
+  exports.Set("GetSourceDimensions", Napi::Function::New(env, ObsGetSourceDimensions));
   exports.Set("SetMuteAudioInputs", Napi::Function::New(env, ObsSetMuteAudioInputs));
   exports.Set("SetSourceVolume", Napi::Function::New(env, ObsSetSourceVolume));
   exports.Set("SetVolmeterEnabled", Napi::Function::New(env, ObsSetVolmeterEnabled));

--- a/src/obs_interface.cpp
+++ b/src/obs_interface.cpp
@@ -1,9 +1,18 @@
+#ifdef _WIN32
 #include <windows.h>
+#endif
 #include <obs.h>
 #include "utils.h"
 #include "obs_interface.h"
 #include <vector>
 #include <string>
+#include <cstring>
+#include <stdexcept>
+#include <thread>
+#include <chrono>
+#ifndef _WIN32
+#include <sys/stat.h>
+#endif
 #include <graphics/matrix4.h>
 #include <graphics/vec4.h>
 #include <util/platform.h>
@@ -136,7 +145,11 @@ int ObsInterface::reset_video(int fps, int width, int height) {
   ovi.scale_type = OBS_SCALE_BILINEAR;
   ovi.adapter = 0;
   ovi.gpu_conversion = true;
-  ovi.graphics_module = "libobs-d3d11.dll"; 
+#ifdef _WIN32
+  ovi.graphics_module = "libobs-d3d11.dll";
+#else
+  ovi.graphics_module = "libobs-opengl.so";
+#endif 
 
   int rc = obs_reset_video(&ovi);
 
@@ -168,22 +181,48 @@ void ObsInterface::init_obs(const std::string& distPath) {
     blog(LOG_ERROR, "OBS not initialized!");
     throw std::runtime_error("OBS initialization failed");
   }
-  
+
+#ifdef _WIN32
   std::string basePath = distPath;
 
   if (basePath.back() != '/' && basePath.back() != '\\') {
-    // Add a trailing slash if not present.
     basePath += '/';
   }
 
   std::string effectsPath = basePath + "data/effects/";
   std::string pluginPath = basePath + "obs-plugins/";
   std::string pluginDataPath = basePath + "data/obs-plugins/";
+#else
+  (void)distPath;
+  std::string effectsPath = "/usr/share/obs/libobs/";
+  std::string pluginDataPath = "/usr/share/obs/obs-plugins/";
 
-  blog(LOG_INFO, "Base path: %s", basePath.c_str());
+  // Plugin library path varies by distro.
+  std::string pluginPath;
+  const char* pluginCandidates[] = {
+    "/usr/lib64/obs-plugins/",
+    "/usr/lib/x86_64-linux-gnu/obs-plugins/",
+    "/usr/lib/obs-plugins/",
+    nullptr
+  };
+
+  for (int i = 0; pluginCandidates[i]; i++) {
+    struct stat st;
+    if (stat(pluginCandidates[i], &st) == 0 && S_ISDIR(st.st_mode)) {
+      pluginPath = pluginCandidates[i];
+      break;
+    }
+  }
+
+  if (pluginPath.empty()) {
+    blog(LOG_WARNING, "OBS plugin directory not found, falling back to /usr/lib64/obs-plugins/");
+    pluginPath = "/usr/lib64/obs-plugins/";
+  }
+#endif
+
   blog(LOG_INFO, "Effects path: %s", effectsPath.c_str());
   blog(LOG_INFO, "Plugin path: %s", pluginPath.c_str());
-  blog(LOG_INFO, "Data path: %s", pluginDataPath.c_str());
+  blog(LOG_INFO, "Plugin data path: %s", pluginDataPath.c_str());
 
   // Add the effects path. We need this before resetting video and audio
   // to ensure the effects are available. The function is deprecated in
@@ -204,7 +243,8 @@ void ObsInterface::init_obs(const std::string& distPath) {
     throw std::runtime_error("Failed to reset audio!");
   }
 
-  std::vector<std::string> modules = { 
+#ifdef _WIN32
+  std::vector<std::string> modules = {
     "obs-x264",     // Software encoder.
     "obs-ffmpeg",   // Contains AMF (AMD) encoder support.
     "win-capture",  // Required for basically all forms of capture on Windows.
@@ -214,18 +254,39 @@ void ObsInterface::init_obs(const std::string& distPath) {
     "obs-qsv11",    // Required for QSV video encoding.
     "obs-filters"   // Required for audio filters.
   };
+  std::string moduleExt = ".dll";
+#else
+  std::vector<std::string> modules = {
+    "obs-x264",           // Software encoder.
+    "obs-ffmpeg",         // Contains VAAPI/AMD encoder support and muxers.
+    "obs-nvenc",          // NVIDIA NVENC hardware encoder.
+    "linux-capture",      // Required for capture on Linux (X11).
+    "linux-pipewire",     // Required for PipeWire screen capture (Wayland/X11).
+    "image-source",       // Required for image sources.
+    "linux-pulseaudio",   // Required for PulseAudio audio input.
+    "obs-filters",        // Required for audio filters.
+    "obs-libfdk"          // FDK-AAC audio encoder, avoids FFmpeg ABI issues on Linux.
+  };
+  std::string moduleExt = ".so";
+#endif
 
   for (const auto& module : modules) {
-    std::string modulePath = pluginPath + module + ".dll";
+    std::string modulePath = pluginPath + module + moduleExt;
     std::string moduleDataPath = pluginDataPath + module;
 
-    // NVENC fails if there is no NVENC hardware support.
-    bool allowFail = module == "obs-nvenc";
+    // NVENC/QSV fail if there is no hardware support.
+    // On Linux, capture plugins may fail depending on display server setup.
+    // obs-libfdk may not be installed on all distributions.
+    bool allowFail = (module == "obs-nvenc") || (module == "obs-qsv11") ||
+                     (module == "linux-capture") || (module == "linux-pipewire") ||
+                     (module == "obs-libfdk");
     load_module(modulePath.c_str(), moduleDataPath.c_str(), allowFail);
   }
-  
+
   obs_post_load_modules();
+#ifdef _WIN32
   register_preview_window_class();
+#endif
 
   list_encoders();
   list_source_types();
@@ -258,15 +319,26 @@ void ObsInterface::create_output() {
 
   if (buffering) {
     blog(LOG_INFO, "Set replay buffer settings");
+#ifdef _WIN32
     obs_data_set_int(settings, "max_time_sec", 60);
     obs_data_set_int(settings, "max_size_mb", 1024);
+#else
+    // Larger buffer since we save at encounter end on Linux.
+    obs_data_set_int(settings, "max_time_sec", 1200);
+    obs_data_set_int(settings, "max_size_mb", 4096);
+#endif
     obs_data_set_string(settings, "directory", recording_path.c_str());
     obs_data_set_string(settings, "format", "%CCYY-%MM-%DD %hh-%mm-%ss");
     obs_data_set_string(settings, "extension", file_extension.c_str());
   } else {
     blog(LOG_INFO, "Set ffmpeg_muxer settings");
     // Need to specify the exact path for ffmpeg_muxer. We will write this again at start recording.
-    std::string filename = recording_path + "\\" + get_current_date_time() + "." + file_extension;
+#ifdef _WIN32
+    std::string pathSep = "\\";
+#else
+    std::string pathSep = "/";
+#endif
+    std::string filename = recording_path + pathSep + get_current_date_time() + "." + file_extension;
     obs_data_set_string(settings, "path", filename.c_str());
     unbuffered_output_filename = filename;
   }
@@ -333,24 +405,68 @@ void ObsInterface::create_audio_encoders() {
     audio_encoder = nullptr;
   }
 
+  // Create encoder settings with explicit sample rate
+  obs_data_t *enc_settings = obs_data_create();
+  obs_data_set_int(enc_settings, "bitrate", 128);
+  obs_data_set_int(enc_settings, "samplerate", 48000);
+
+#ifndef _WIN32
+  // Prefer FDK-AAC on Linux to avoid FFmpeg ABI incompatibilities.
+  // Falls back to ffmpeg_aac or ffmpeg_opus if unavailable.
+  blog(LOG_INFO, "Linux: Trying FDK-AAC encoder");
   audio_encoder = obs_audio_encoder_create(
-    "ffmpeg_aac", 
-    "aac_file",
-    NULL, 
-    0, 
+    "libfdk_aac",
+    "fdk_file",
+    enc_settings,
+    0,
     NULL
   );
 
+  if (audio_encoder) {
+    blog(LOG_INFO, "FDK-AAC encoder created successfully");
+  } else {
+    blog(LOG_INFO, "FDK-AAC not available, trying FFmpeg AAC");
+  }
+#endif
+
   if (!audio_encoder) {
-    blog(LOG_ERROR, "Failed to create audio encoder!");
-    throw std::runtime_error("Failed to create audio encoder!");
+    audio_encoder = obs_audio_encoder_create(
+      "ffmpeg_aac",
+      "aac_file",
+      enc_settings,
+      0,
+      NULL
+    );
+    if (audio_encoder) {
+      blog(LOG_INFO, "FFmpeg AAC encoder created successfully");
+    }
   }
 
-  blog(LOG_INFO, "Set audio encoder settings");
-  obs_data_t *aenc_settings = obs_data_create();
-  obs_data_set_int(aenc_settings, "bitrate", 128);
-  obs_encoder_update(audio_encoder, aenc_settings);
-  obs_data_release(aenc_settings);
+  if (!audio_encoder) {
+    blog(LOG_INFO, "AAC encoder not available, trying Opus");
+    audio_encoder = obs_audio_encoder_create(
+      "ffmpeg_opus",
+      "opus_file",
+      enc_settings,
+      0,
+      NULL
+    );
+    if (audio_encoder) {
+      blog(LOG_INFO, "FFmpeg Opus encoder created successfully");
+    }
+  }
+
+  obs_data_release(enc_settings);
+
+  if (!audio_encoder) {
+    blog(LOG_WARNING, "No audio encoder available - recording will be video-only!");
+    blog(LOG_WARNING, "On Linux, try installing: fdk-aac-free (Fedora) or libfdk-aac2 (Debian/Ubuntu)");
+    audio_disabled = true;
+    return;
+  }
+
+  audio_disabled = false;
+  blog(LOG_INFO, "Audio encoder created successfully");
 
   obs_output_set_audio_encoder(output, audio_encoder, 0);
   obs_encoder_set_audio(audio_encoder, obs_get_audio());
@@ -590,6 +706,23 @@ obs_properties_t* ObsInterface::getSourceProperties(std::string name) {
   return props;
 }
 
+SourceSize ObsInterface::getSourceDimensions(std::string name) {
+  blog(LOG_INFO, "Get source dimensions for: %s", name.c_str());
+  auto it = sources.find(name);
+
+  if (it == sources.end()) {
+    blog(LOG_WARNING, "Source %s not found when getting dimensions", name.c_str());
+    throw std::runtime_error("Source not found!");
+  }
+
+  obs_source_t* source = it->second;
+  uint32_t width = obs_source_get_width(source);
+  uint32_t height = obs_source_get_height(source);
+
+  blog(LOG_INFO, "Source %s dimensions: %dx%d", name.c_str(), width, height);
+  return { width, height };
+}
+
 void ObsInterface::output_signal_handler(void *data, calldata_t *cd) {
   long long code = calldata_int(cd, "code");
   const char *err = calldata_string(cd, "last_error");
@@ -765,16 +898,17 @@ void draw_callback(void* data, uint32_t cx, uint32_t cy) {
   }
 }
 
-void ObsInterface::initPreview(HWND parent) {
+void ObsInterface::initPreview(NativeWindowHandle parent) {
   blog(LOG_INFO, "ObsInterface::initPreview");
 
+#ifdef _WIN32
   if (!preview_hwnd) {
     blog(LOG_INFO, "Creating preview child window");
 
     preview_hwnd = CreateWindowEx(
-      0,         
+      0,
       TEXT("PreviewWindowClass"),   // Window class we already registered earlier
-      TEXT("OBS Preview"),          // Window name 
+      TEXT("OBS Preview"),          // Window name
       WS_POPUP,
       0, 0,                   // Initial position (x, y)
       0, 0,                   // Initial size (width, height)
@@ -824,11 +958,193 @@ void ObsInterface::initPreview(HWND parent) {
   }
 
   obs_display_set_enabled(display, false);
+#else
+  blog(LOG_INFO, "Initializing Linux preview with parent window: %u", parent);
+
+  if (parent == 0) {
+    blog(LOG_ERROR, "Invalid parent window ID");
+    return;
+  }
+
+  // Detect display server type
+  display_server = detectDisplayServer();
+
+  switch (display_server) {
+    case LinuxDisplayServer::X11:
+      blog(LOG_INFO, "Using X11 display server");
+      if (!initX11Preview(parent)) {
+        blog(LOG_ERROR, "Failed to initialize X11 preview");
+        return;
+      }
+      break;
+
+    case LinuxDisplayServer::XWAYLAND:
+      blog(LOG_INFO, "Using XWayland (Wayland session with X11 compatibility)");
+      // XWayland provides X11 compatibility, so we can use the X11 path
+      if (!initX11Preview(parent)) {
+        blog(LOG_ERROR, "Failed to initialize XWayland preview");
+        return;
+      }
+      break;
+
+    case LinuxDisplayServer::WAYLAND:
+      blog(LOG_WARNING, "Pure Wayland detected, attempting XWayland fallback");
+      if (!initX11Preview(parent)) {
+        blog(LOG_ERROR, "Preview not available on pure Wayland without XWayland");
+        blog(LOG_INFO, "Consider running the app with: GDK_BACKEND=x11 or enabling XWayland");
+        return;
+      }
+      break;
+
+    default:
+      blog(LOG_WARNING, "Unknown display server, attempting X11");
+      if (!initX11Preview(parent)) {
+        blog(LOG_ERROR, "Failed to initialize preview");
+        return;
+      }
+      break;
+  }
+
+  obs_display_set_enabled(display, false);
+#endif
 }
+
+#ifndef _WIN32
+LinuxDisplayServer ObsInterface::detectDisplayServer() {
+  // Check XDG_SESSION_TYPE first (most reliable on modern systems)
+  const char* session_type = std::getenv("XDG_SESSION_TYPE");
+  const char* wayland_display = std::getenv("WAYLAND_DISPLAY");
+  const char* x11_display_env = std::getenv("DISPLAY");
+
+  blog(LOG_INFO, "Display server detection:");
+  blog(LOG_INFO, "  XDG_SESSION_TYPE: %s", session_type ? session_type : "(not set)");
+  blog(LOG_INFO, "  WAYLAND_DISPLAY: %s", wayland_display ? wayland_display : "(not set)");
+  blog(LOG_INFO, "  DISPLAY: %s", x11_display_env ? x11_display_env : "(not set)");
+
+  if (session_type) {
+    if (strcmp(session_type, "wayland") == 0) {
+      // Running on Wayland session
+      if (x11_display_env) {
+        // DISPLAY is set, XWayland is available
+        blog(LOG_INFO, "Detected: Wayland session with XWayland");
+        return LinuxDisplayServer::XWAYLAND;
+      } else {
+        // Pure Wayland, no XWayland
+        blog(LOG_INFO, "Detected: Pure Wayland (no XWayland)");
+        return LinuxDisplayServer::WAYLAND;
+      }
+    } else if (strcmp(session_type, "x11") == 0) {
+      blog(LOG_INFO, "Detected: X11 session");
+      return LinuxDisplayServer::X11;
+    }
+  }
+
+  // Fallback detection
+  if (wayland_display && x11_display_env) {
+    blog(LOG_INFO, "Detected: Wayland with XWayland (fallback)");
+    return LinuxDisplayServer::XWAYLAND;
+  } else if (wayland_display) {
+    blog(LOG_INFO, "Detected: Wayland (fallback)");
+    return LinuxDisplayServer::WAYLAND;
+  } else if (x11_display_env) {
+    blog(LOG_INFO, "Detected: X11 (fallback)");
+    return LinuxDisplayServer::X11;
+  }
+
+  blog(LOG_WARNING, "Could not detect display server");
+  return LinuxDisplayServer::UNKNOWN;
+}
+
+bool ObsInterface::initX11Preview(NativeWindowHandle parent) {
+  // Store the parent window ID
+  x11_parent_window = parent;
+
+  // Open connection to X11 display
+  if (!x11_display) {
+    x11_display = XOpenDisplay(NULL);
+    if (!x11_display) {
+      blog(LOG_ERROR, "Failed to open X11 display connection");
+      return false;
+    }
+    blog(LOG_INFO, "X11 display connection opened");
+  }
+
+  // Create a child window for the preview
+  if (!x11_preview_window) {
+    blog(LOG_INFO, "Creating X11 preview child window for parent: %u", parent);
+
+    // Get the parent window's attributes to understand its properties
+    XWindowAttributes parent_attrs;
+    if (!XGetWindowAttributes(x11_display, x11_parent_window, &parent_attrs)) {
+      blog(LOG_ERROR, "Failed to get parent window attributes - window may not exist or be accessible");
+      return false;
+    }
+
+    blog(LOG_INFO, "Parent window: screen=%d, visual depth=%d, width=%d, height=%d",
+         XScreenNumberOfScreen(parent_attrs.screen),
+         parent_attrs.depth,
+         parent_attrs.width,
+         parent_attrs.height);
+
+    // Create a simple window as a child of the parent
+    // Initial size 1x1, will be resized by configurePreview
+    x11_preview_window = XCreateSimpleWindow(
+      x11_display,
+      x11_parent_window,  // Parent window
+      0, 0,               // Position (x, y)
+      1, 1,               // Size (width, height) - will be configured later
+      0,                  // Border width
+      BlackPixel(x11_display, DefaultScreen(x11_display)),  // Border color
+      BlackPixel(x11_display, DefaultScreen(x11_display))   // Background color
+    );
+
+    if (!x11_preview_window) {
+      blog(LOG_ERROR, "Failed to create X11 preview window");
+      return false;
+    }
+
+    blog(LOG_INFO, "X11 preview window created: %lu", x11_preview_window);
+
+    // Select events we want to receive
+    XSelectInput(x11_display, x11_preview_window, ExposureMask | StructureNotifyMask);
+
+    // Flush to ensure window is created
+    XFlush(x11_display);
+  }
+
+  // Create OBS display with the X11 window
+  if (!display) {
+    blog(LOG_INFO, "Creating OBS display for X11 window");
+
+    gs_init_data gs_data = {};
+    gs_data.adapter = 0;
+    gs_data.cx = 1920; // Gets overwritten when we call configurePreview()
+    gs_data.cy = 1080; // Gets overwritten when we call configurePreview()
+    gs_data.format = GS_BGRA;
+    gs_data.zsformat = GS_ZS_NONE;
+    gs_data.num_backbuffers = 1;
+    gs_data.window.id = x11_preview_window;
+    gs_data.window.display = x11_display;
+
+    display = obs_display_create(&gs_data, 0x0);
+
+    if (!display) {
+      blog(LOG_ERROR, "Failed to create OBS display - check OBS/OpenGL initialization");
+      return false;
+    }
+
+    blog(LOG_INFO, "OBS display created successfully");
+    obs_display_add_draw_callback(display, draw_callback, this);
+  }
+
+  return true;
+}
+#endif
 
 void ObsInterface::configurePreview(int x, int y, int width, int height) {
   blog(LOG_INFO, "ObsInterface::configurePreview");
 
+#ifdef _WIN32
   if (!preview_hwnd) {
     blog(LOG_ERROR, "Preview window not initialized");
     return;
@@ -857,11 +1173,33 @@ void ObsInterface::configurePreview(int x, int y, int width, int height) {
 
   obs_display_resize(display, width, height);
   obs_display_set_enabled(display, true);
+#else
+  if (!x11_display || !x11_preview_window) {
+    blog(LOG_ERROR, "X11 preview not initialized");
+    return;
+  }
+
+  if (!display) {
+    blog(LOG_ERROR, "OBS display not initialized");
+    return;
+  }
+
+  blog(LOG_INFO, "Configuring X11 preview: position (%d, %d), size (%d x %d)", x, y, width, height);
+
+  // Move and resize the X11 preview window
+  XMoveResizeWindow(x11_display, x11_preview_window, x, y, width, height);
+  XFlush(x11_display);
+
+  // Resize the OBS display
+  obs_display_resize(display, width, height);
+  obs_display_set_enabled(display, true);
+#endif
 }
 
 void ObsInterface::showPreview() {
   blog(LOG_INFO, "ObsInterface::showPreview");
 
+#ifdef _WIN32
   if (!preview_hwnd) {
     blog(LOG_ERROR, "Preview window not initialized");
     return;
@@ -874,20 +1212,45 @@ void ObsInterface::showPreview() {
 
   ShowWindow(preview_hwnd, SW_SHOW);
   obs_display_set_enabled(display, true);
+#else
+  if (!x11_display || !x11_preview_window) {
+    blog(LOG_ERROR, "X11 preview not initialized");
+    return;
+  }
+
+  if (!display) {
+    blog(LOG_ERROR, "OBS display not initialized");
+    return;
+  }
+
+  blog(LOG_INFO, "Showing X11 preview window");
+  XMapWindow(x11_display, x11_preview_window);
+  XFlush(x11_display);
+  obs_display_set_enabled(display, true);
+#endif
 }
 
 void ObsInterface::hidePreview() {
   blog(LOG_INFO, "ObsInterface::hidePreview");
 
+#ifdef _WIN32
   if (preview_hwnd) {
     ShowWindow(preview_hwnd, SW_HIDE);
     blog(LOG_INFO, "Preview child window hidden");
   }
+#else
+  if (x11_display && x11_preview_window) {
+    blog(LOG_INFO, "Hiding X11 preview window");
+    XUnmapWindow(x11_display, x11_preview_window);
+    XFlush(x11_display);
+  }
+#endif
 }
 
 void ObsInterface::disablePreview() {
   blog(LOG_INFO, "ObsInterface::disablePreview");
 
+#ifdef _WIN32
   if (!display) {
     blog(LOG_ERROR, "Preview display not initialized");
     return;
@@ -895,19 +1258,29 @@ void ObsInterface::disablePreview() {
 
   hidePreview();
   obs_display_set_enabled(display, false);
+#else
+  if (!display) {
+    blog(LOG_ERROR, "OBS display not initialized");
+    return;
+  }
+
+  hidePreview();
+  obs_display_set_enabled(display, false);
+#endif
 }
 
 PreviewInfo ObsInterface::getPreviewInfo() {
-  if (!display) {
-    blog(LOG_WARNING, "Display not initialized when calling getPreviewInfo");
-    return { 1920, 1080, 1920, 1080 }; // Default values
-  }
-
   obs_video_info ovi;
   obs_get_video_info(&ovi);
 
+#ifdef _WIN32
+  if (!display) {
+    blog(LOG_WARNING, "Display not initialized when calling getPreviewInfo");
+    return { ovi.base_width, ovi.base_height, ovi.base_width, ovi.base_height };
+  }
+
   uint32_t width, height;
-	obs_display_size(display, &width, &height);
+  obs_display_size(display, &width, &height);
 
   PreviewInfo info = {
     ovi.base_width,
@@ -917,6 +1290,24 @@ PreviewInfo ObsInterface::getPreviewInfo() {
   };
 
   return info;
+#else
+  if (!display) {
+    blog(LOG_WARNING, "Display not initialized when calling getPreviewInfo");
+    return { ovi.base_width, ovi.base_height, ovi.base_width, ovi.base_height };
+  }
+
+  uint32_t width, height;
+  obs_display_size(display, &width, &height);
+
+  PreviewInfo info = {
+    ovi.base_width,
+    ovi.base_height,
+    width,
+    height,
+  };
+
+  return info;
+#endif
 }
 
 void ObsInterface::setDrawSourceOutline(bool enabled) {
@@ -1026,6 +1417,28 @@ ObsInterface::~ObsInterface() {
   //   obs_encoder_release(audio_encoder);
   // }
 
+  // Clean up display before shutting down OBS
+  if (display) {
+    blog(LOG_DEBUG, "Destroying OBS display");
+    obs_display_destroy(display);
+    display = nullptr;
+  }
+
+#ifndef _WIN32
+  // Clean up X11 resources on Linux
+  if (x11_preview_window && x11_display) {
+    blog(LOG_DEBUG, "Destroying X11 preview window");
+    XDestroyWindow(x11_display, x11_preview_window);
+    x11_preview_window = 0;
+  }
+
+  if (x11_display) {
+    blog(LOG_DEBUG, "Closing X11 display connection");
+    XCloseDisplay(x11_display);
+    x11_display = nullptr;
+  }
+#endif
+
   blog(LOG_DEBUG, "Now shutting down OBS");
   obs_shutdown();
 
@@ -1067,13 +1480,69 @@ void ObsInterface::startBuffering() {
     return;
   }
 
+  blog(LOG_INFO, "Validating OBS state before starting buffer");
+
+  // Check video output is configured
+  video_t *video = obs_get_video();
+  if (!video) {
+    blog(LOG_ERROR, "No video output configured!");
+    throw std::runtime_error("No video output configured!");
+  }
+  blog(LOG_INFO, "  Video output: configured");
+
+  // Check audio output is configured
+  audio_t *audio = obs_get_audio();
+  if (!audio) {
+    blog(LOG_ERROR, "No audio output configured!");
+    throw std::runtime_error("No audio output configured!");
+  }
+  blog(LOG_INFO, "  Audio output: configured");
+
+  // Check scene is set as output source
+  obs_source_t *scene_source = obs_get_output_source(0);
+  if (!scene_source) {
+    blog(LOG_ERROR, "No scene source set as output!");
+    throw std::runtime_error("No scene source set as output!");
+  }
+  uint32_t scene_width = obs_source_get_width(scene_source);
+  uint32_t scene_height = obs_source_get_height(scene_source);
+  blog(LOG_INFO, "  Scene source: %s (%ux%u)", obs_source_get_name(scene_source), scene_width, scene_height);
+  obs_source_release(scene_source);
+
+  // Check encoders
+  blog(LOG_INFO, "About to call obs_output_start...");
+  blog(LOG_INFO, "  Output type: %s", obs_output_get_id(output));
+  blog(LOG_INFO, "  Video encoder: %s", video_encoder ? obs_encoder_get_id(video_encoder) : "NULL");
+  blog(LOG_INFO, "  Audio encoder: %s", audio_encoder ? obs_encoder_get_id(audio_encoder) : "NULL");
+
+  if (!video_encoder) {
+    blog(LOG_ERROR, "No video encoder set!");
+    throw std::runtime_error("No video encoder set!");
+  }
+
+  if (!audio_encoder) {
+    if (audio_disabled) {
+      blog(LOG_WARNING, "Audio encoder disabled - recording will be video-only");
+    } else {
+      blog(LOG_ERROR, "No audio encoder set!");
+      throw std::runtime_error("No audio encoder set!");
+    }
+  }
+
+  // Check if encoders are active
+  blog(LOG_INFO, "  Video encoder active: %s", obs_encoder_active(video_encoder) ? "yes" : "no");
+  blog(LOG_INFO, "  Audio encoder active: %s", audio_encoder ? (obs_encoder_active(audio_encoder) ? "yes" : "no") : "disabled");
+
+  blog(LOG_INFO, "Calling obs_output_start NOW");
   bool success = obs_output_start(output);
+  blog(LOG_INFO, "obs_output_start returned: %s", success ? "true" : "false");
 
   if (!success) {
-    blog(LOG_ERROR, "Failed to start buffering!");
+    const char *err = obs_output_get_last_error(output);
+    blog(LOG_ERROR, "Failed to start buffering! Error: %s", err ? err : "Unknown");
     throw std::runtime_error("Failed to start buffering!");
   }
-    
+
   blog(LOG_INFO, "ObsInterface::startBuffering exited");
 }
 
@@ -1093,21 +1562,42 @@ void ObsInterface::startRecording(int offset) {
       throw std::runtime_error("Buffer is not active");
     }
 
-    blog(LOG_INFO, "calling save proc handler");
+#ifdef _WIN32
+    blog(LOG_INFO, "Saving replay buffer to file with offset %d", offset);
     calldata cd;
     calldata_init(&cd);
-    calldata_set_int(&cd, "offset_seconds", offset);
     proc_handler_t *ph = obs_output_get_proc_handler(output);
+
+    if (!ph) {
+      blog(LOG_ERROR, "Failed to get proc handler from output");
+      throw std::runtime_error("Failed to get proc handler from output");
+    }
+
+    calldata_set_int(&cd, "offset_seconds", offset);
     bool success = proc_handler_call(ph, "convert", &cd);
     calldata_free(&cd);
 
     if (!success) {
-      blog(LOG_ERROR, "Failed to call convert procedure handler");
-      throw std::runtime_error("Failed to call convert procedure handler");
+      const char *last_error = obs_output_get_last_error(output);
+      blog(LOG_ERROR, "Failed to save replay buffer. Error: %s", last_error ? last_error : "unknown");
+      blog(LOG_ERROR, "Output active: %s", obs_output_active(output) ? "yes" : "no");
+      blog(LOG_ERROR, "Output type: %s", obs_output_get_id(output));
+      throw std::runtime_error("Failed to save replay buffer");
     }
+
+    blog(LOG_INFO, "Replay buffer save triggered successfully");
+#else
+    // On Linux, the buffer is saved at encounter end instead.
+    blog(LOG_INFO, "Linux: Recording started, will save buffer at encounter end (offset %d ignored)", offset);
+#endif
   } else {
     obs_data_t *ffmpeg_settings = obs_data_create();
-    std::string filename = recording_path + "\\" + get_current_date_time() + "." + file_extension;
+#ifdef _WIN32
+    std::string pathSep = "\\";
+#else
+    std::string pathSep = "/";
+#endif
+    std::string filename = recording_path + pathSep + get_current_date_time() + "." + file_extension;
     obs_data_set_string(ffmpeg_settings,  "path", filename.c_str());
     obs_output_update(output, ffmpeg_settings);
     obs_data_release(ffmpeg_settings);
@@ -1143,6 +1633,59 @@ void ObsInterface::stopRecording() {
     blog(LOG_WARNING, "Output is not active");
     return;
   }
+
+#ifndef _WIN32
+  if (buffering) {
+    blog(LOG_INFO, "Linux: Saving replay buffer at encounter end");
+    proc_handler_t *ph = obs_output_get_proc_handler(output);
+
+    if (ph) {
+      calldata old_cd;
+      calldata_init(&old_cd);
+      proc_handler_call(ph, "get_last_replay", &old_cd);
+      const char* old_path_ptr = calldata_string(&old_cd, "path");
+      std::string old_path = old_path_ptr ? old_path_ptr : "";
+      calldata_free(&old_cd);
+      blog(LOG_INFO, "Linux: Previous last_replay path: %s", old_path.c_str());
+
+      // Trigger the save
+      calldata cd;
+      calldata_init(&cd);
+      bool success = proc_handler_call(ph, "save", &cd);
+      calldata_free(&cd);
+
+      if (success) {
+        blog(LOG_INFO, "Linux: Replay buffer save triggered, waiting for completion");
+        for (int i = 0; i < 100; i++) {
+          std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+          // Check if the file path has CHANGED (not just exists)
+          calldata check_cd;
+          calldata_init(&check_cd);
+          proc_handler_call(ph, "get_last_replay", &check_cd);
+          const char* check_path = calldata_string(&check_cd, "path");
+          std::string new_path = check_path ? check_path : "";
+          calldata_free(&check_cd);
+
+          if (!new_path.empty() && new_path != old_path) {
+            blog(LOG_INFO, "Linux: Save completed, new file: %s", new_path.c_str());
+            break;
+          }
+
+          if (i == 99) {
+            blog(LOG_WARNING, "Linux: Timed out waiting for save to complete (path unchanged)");
+          }
+        }
+      } else {
+        const char *last_error = obs_output_get_last_error(output);
+        blog(LOG_ERROR, "Linux: Failed to save replay buffer. Error: %s",
+             last_error ? last_error : "unknown");
+      }
+    } else {
+      blog(LOG_ERROR, "Linux: Failed to get proc handler for save");
+    }
+  }
+#endif
 
   obs_output_stop(output);
   blog(LOG_INFO, "ObsInterface::stopRecording exited");

--- a/src/obs_interface.h
+++ b/src/obs_interface.h
@@ -2,14 +2,32 @@
 
 #include <obs.h>
 #include <napi.h>
-#include <windows.h>
 #include <map>
 #include <string>
 #include <optional>
 
+#ifdef _WIN32
+#include <windows.h>
 #define AUDIO_INPUT "wasapi_input_capture"
 #define AUDIO_OUTPUT "wasapi_output_capture"
 #define AUDIO_PROCESS "wasapi_process_output_capture"
+typedef HWND NativeWindowHandle;
+#else
+// Linux - X11 and Wayland support
+#include <X11/Xlib.h>
+#include <cstdlib>  // for getenv
+#define AUDIO_INPUT "pulse_input_capture"
+#define AUDIO_OUTPUT "pulse_output_capture"
+#define AUDIO_PROCESS "pulse_output_capture"  // No direct equivalent on Linux
+typedef uint32_t NativeWindowHandle;  // X11 Window ID (XID) - also used via XWayland
+
+enum class LinuxDisplayServer {
+  UNKNOWN,
+  X11,
+  WAYLAND,
+  XWAYLAND  // Wayland session but using XWayland for this window
+};
+#endif
 
 class ObsInterface;
 
@@ -60,6 +78,7 @@ class ObsInterface {
     obs_data_t* getSourceSettings(std::string name); // Get the current settings.
     void setSourceSettings(std::string name, obs_data_t* settings); // Set settings.
     obs_properties_t* getSourceProperties(std::string name); // Get the settings schema.
+    SourceSize getSourceDimensions(std::string name); // Get the current width and height of a source.
     void setMuteAudioInputs(bool mute); // Mute or unmute all audio inputs.
     void setSourceVolume(std::string name, float volume); // Set the volume of an audio source.
     void setVolmeterEnabled(bool enabled); // Enable volmeters.
@@ -71,7 +90,7 @@ class ObsInterface {
     void getSourcePos(std::string name, vec2* pos, vec2* size, vec2* scale, obs_sceneitem_crop* crop); // Size is returned to allow clients to calculate scale.
     void setSourcePos(std::string name, vec2* pos, vec2* scale, obs_sceneitem_crop* crop); // Size does not get set here because it's set by the source itself.
 
-    void initPreview(HWND parent); // Must call this before showPreview to setup resources.
+    void initPreview(NativeWindowHandle parent); // Must call this before showPreview to setup resources.
     void configurePreview(int x, int y, int width, int height); // Move and resize the preview display.
     void showPreview(); // Show the preview display.
     void hidePreview(); // Hide the preview display, but leave it running.
@@ -83,8 +102,8 @@ class ObsInterface {
     std::vector<std::string> listAvailableVideoEncoders(); // Return a list of available video encoders.
     void setVideoEncoder(std::string id, obs_data_t* settings); // Set the video encoder to use.
 
-    std::map<std::string, obs_source_t*> sources; // Map of source names to obs_source_t pointers. 
-    std::map<std::string, SourceSize> sizes; // Map of source names to their last known size, used for firing callbacks on size changes. 
+    std::map<std::string, obs_source_t*> sources; // Map of source names to obs_source_t pointers.
+    std::map<std::string, SourceSize> sizes; // Map of source names to their last known size, used for firing callbacks on size changes.
     std::map<std::string, obs_volmeter_t*> volmeters; // Map of source names to obs_volmeter_t pointers.
     std::map<std::string, SignalContext*> volmeter_cb_ctx; // Map of volmeter callback contexts.
     std::map<std::string, obs_source_t*> filters; // Map of source names to obs_source_t filter pointers.
@@ -99,11 +118,22 @@ class ObsInterface {
 
     obs_encoder_t *video_encoder = nullptr;
     obs_encoder_t *audio_encoder = nullptr;
-    
+
     obs_display_t *display = nullptr;
-    HWND preview_hwnd = nullptr; // window handle for scene preview
+#ifdef _WIN32
+    NativeWindowHandle preview_hwnd = nullptr; // window handle for scene preview
+#else
+    // Linux preview members
+    LinuxDisplayServer display_server = LinuxDisplayServer::UNKNOWN;
+    Display* x11_display = nullptr;
+    Window x11_preview_window = 0;
+    Window x11_parent_window = 0;
+
+    LinuxDisplayServer detectDisplayServer();
+    bool initX11Preview(NativeWindowHandle parent);
+#endif
     Napi::ThreadSafeFunction jscb; // javascript callback
-    std::string recording_path = ""; 
+    std::string recording_path = "";
     std::string unbuffered_output_filename = "";
     std::string file_extension = "mp4"; // File extension for recordings.
 
@@ -140,11 +170,16 @@ class ObsInterface {
     bool volmeter_enabled = false; // Whether the volmeter callback is enabled.
     bool audio_suppression = false; // Whether audio suppression is enabled.
     bool force_mono = false; // Whether force mono audio is enabled.
+    bool audio_disabled = false; // Whether audio encoding is disabled (fallback for broken FFmpeg).
 
     static void volmeter_callback(
-      void *data, 
+      void *data,
       const float magnitude[MAX_AUDIO_CHANNELS],
-      const float peak[MAX_AUDIO_CHANNELS], 
+      const float peak[MAX_AUDIO_CHANNELS],
       const float inputPeak[MAX_AUDIO_CHANNELS]
     );
+
+#ifdef _WIN32
+    void register_preview_window_class();
+#endif
 };

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -5,7 +5,10 @@
 #include <iomanip>
 #include <sstream>
 #include "utils.h"
+
+#ifdef _WIN32
 #include <windows.h>
+#endif
 
 void log_handler(int lvl, const char *msg, va_list args, void *p) {
   static std::stringstream logFileName;
@@ -19,7 +22,11 @@ void log_handler(int lvl, const char *msg, va_list args, void *p) {
     std::string logDir = static_cast<const char*>(p);
 
     if (!logDir.empty() && logDir.back() != '\\' && logDir.back() != '/') {
+#ifdef _WIN32
       logDir += '\\';
+#else
+      logDir += '/';
+#endif
     }
       
     logFileName << logDir << "OBS-" << std::put_time(std::localtime(&t), "%Y-%m-%d") << ".log";
@@ -383,10 +390,11 @@ std::string get_current_date_time() {
     return ss.str();
 }
 
+#ifdef _WIN32
 LRESULT CALLBACK DisplayWndProc(
-  _In_ HWND hwnd, 
-  _In_ UINT uMsg, 
-  _In_ WPARAM wParam, 
+  _In_ HWND hwnd,
+  _In_ UINT uMsg,
+  _In_ WPARAM wParam,
   _In_ LPARAM lParam)
 {
 	switch (uMsg) {
@@ -399,7 +407,7 @@ LRESULT CALLBACK DisplayWndProc(
 
 void register_preview_window_class() {
   WNDCLASSEX klass;
-  
+
   klass.cbSize = sizeof(WNDCLASSEX);
 	klass.style = CS_NOCLOSE | CS_HREDRAW | CS_VREDRAW | CS_OWNDC;
 	klass.lpfnWndProc = DisplayWndProc;
@@ -420,3 +428,4 @@ void register_preview_window_class() {
 
   blog(LOG_INFO, "Registered preview window class");
 }
+#endif // _WIN32

--- a/src/utils.h
+++ b/src/utils.h
@@ -3,7 +3,9 @@
 #include <napi.h>
 #include <obs.h>
 
+#ifdef _WIN32
 void register_preview_window_class();
+#endif
 void log_handler(int lvl, const char *msg, va_list args, void *p);
 
 Napi::Object data_to_napi(Napi::Env env,obs_data_t* data);


### PR DESCRIPTION
## Summary

- Add Linux (PipeWire) support for video/audio capture alongside existing Windows support
- Multi-distro OBS plugin path discovery (Fedora, Debian/Ubuntu, Arch)
- FDK-AAC preferred audio encoder on Linux to avoid FFmpeg ABI incompatibilities, with fallback to ffmpeg_aac/ffmpeg_opus
- Replay buffer save-at-end strategy for Linux (1200s/4GB buffer) since PipeWire capture sources aren't available at encounter start
- X11/XWayland display preview support
- Build system updates in binding.gyp for Linux compilation

## Details

The native OBS addon now compiles and runs on Linux. Key architectural differences from the Windows path:

- **Capture**: PipeWire screen capture source instead of window/game/monitor capture
- **Audio encoding**: FDK-AAC preferred to avoid ABI mismatches between distro-packaged FFmpeg and OBS
- **Replay buffer**: Saved at encounter end rather than start, requiring a larger buffer window
- **Plugin paths**: Probes multiple known locations to support Fedora (`/usr/lib64/`), Debian/Ubuntu (`/usr/lib/x86_64-linux-gnu/`), and Arch (`/usr/lib/`)
- **Preview**: Uses X11 window handle even under Wayland (via XWayland)

## Test plan

- [x] Tested on Fedora 43 with PipeWire
- [ ] Test on Debian/Ubuntu-based distro
- [ ] Test on Arch-based distro
- See `TESTING_CHECKLIST.md` for full test matrix