### PR TITLE
Handle missing source settings at the N-API boundary

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -411,6 +411,12 @@ Napi::Value ObsGetSourceSettings(const Napi::CallbackInfo& info) {
   std::string name = info[0].As<Napi::String>().Utf8Value();
 
   obs_data_t* settings = obs->getSourceSettings(name);
+
+  if (!settings) {
+    Napi::Error::New(info.Env(), "Failed to get settings for source: " + name).ThrowAsJavaScriptException();
+    return info.Env().Undefined();
+  }
+
   Napi::Object result = data_to_napi(info.Env(), settings);
   obs_data_release(settings);
 

--- a/src/obs_interface.cpp
+++ b/src/obs_interface.cpp
@@ -546,7 +546,7 @@ obs_data_t* ObsInterface::getSourceSettings(std::string name) {
 
   if (it == sources.end()) {
     blog(LOG_WARNING, "Source %s not found when getting settings", name.c_str());
-    throw std::runtime_error("Source not found!");
+    return nullptr;
   }
 
   obs_source_t* source = it->second;
@@ -554,7 +554,7 @@ obs_data_t* ObsInterface::getSourceSettings(std::string name) {
   
   if (!settings) {
     blog(LOG_ERROR, "Failed to get settings for source: %s", name.c_str());
-    throw std::runtime_error("Failed to get source settings!");
+    return nullptr;
   }
 
   return settings;


### PR DESCRIPTION
## Summary

- return `nullptr` from `ObsInterface::getSourceSettings` when the source or its settings cannot be found
- translate that failure into a catchable JavaScript `Error` at the N-API boundary
- preserve the existing successful settings conversion and release path

## Root cause

`getSourceSettings` threw `std::runtime_error` for missing settings. With the addon built using `NAPI_DISABLE_CPP_EXCEPTIONS`, that C++ exception could escape the N-API callback and terminate the Node.js process instead of producing a JavaScript exception.

## Impact

Consumers can now catch a missing-source failure as:

```text
Failed to get settings for source: <name>
```

The addon remains usable after the error. The successful-source behavior and TypeScript API are unchanged.

## Validation

- native Windows build with Node.js 24.13.1
- before/after reproduction: unpatched `HEAD` exited with code 1 without reaching the JavaScript `catch`; the patched build returned a catchable `Error`
- verified a valid source returns identical settings before and after the missing-source call
- verified invalid arguments still return `TypeError`
- verified clean `Shutdown()` after the caught error
- `npm run test-errors`
- `npm run test-preview`
- `npx tsc --noEmit --project test/tsconfig.json`
- package-level E2E using `npm pack` and a fresh consumer installation
