### PR TITLE
Catch native exceptions at the N-API boundary

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -19,5 +19,10 @@
             "<!(node -p \"require('node-addon-api').gyp\")"
         ],
         'defines': [ 'NAPI_DISABLE_CPP_EXCEPTIONS' ],
+        'msvs_settings': {
+            'VCCLCompilerTool': {
+                'ExceptionHandling': 1,
+            },
+        },
     }]
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,10 +1,24 @@
 #include <napi.h>
 #include <windows.h>
 #include <obs.h>
+#include <exception>
 #include "obs_interface.h"
 #include "utils.h"
 
 ObsInterface* obs = nullptr;
+
+template <Napi::Value (*Callback)(const Napi::CallbackInfo&)>
+Napi::Value CatchNativeExceptions(const Napi::CallbackInfo& info) {
+  try {
+    return Callback(info);
+  } catch (const std::exception& error) {
+    Napi::Error::New(info.Env(), error.what()).ThrowAsJavaScriptException();
+  } catch (...) {
+    Napi::Error::New(info.Env(), "Unknown native error").ThrowAsJavaScriptException();
+  }
+
+  return info.Env().Undefined();
+}
 
 extern "C" __declspec(dllexport) DWORD NvOptimusEnablement = 1;
 extern "C" __declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
@@ -736,47 +750,47 @@ Napi::Value ObsSetSourceAudioTracks(const Napi::CallbackInfo& info) {
 }
 
 Napi::Object Init(Napi::Env env, Napi::Object exports) {
-  exports.Set("Init", Napi::Function::New(env, ObsInit));
-  exports.Set("Shutdown", Napi::Function::New(env, ObsShutdown));
-  exports.Set("SetRecordingCfg", Napi::Function::New(env, ObsSetRecordingCfg));
-  exports.Set("ResetVideoContext", Napi::Function::New(env, ObsResetVideoContext));
-  exports.Set("ListVideoEncoders", Napi::Function::New(env, ObsListVideoEncoders));
-  exports.Set("SetVideoEncoder", Napi::Function::New(env, ObsSetVideoEncoder));
+  exports.Set("Init", Napi::Function::New(env, CatchNativeExceptions<ObsInit>));
+  exports.Set("Shutdown", Napi::Function::New(env, CatchNativeExceptions<ObsShutdown>));
+  exports.Set("SetRecordingCfg", Napi::Function::New(env, CatchNativeExceptions<ObsSetRecordingCfg>));
+  exports.Set("ResetVideoContext", Napi::Function::New(env, CatchNativeExceptions<ObsResetVideoContext>));
+  exports.Set("ListVideoEncoders", Napi::Function::New(env, CatchNativeExceptions<ObsListVideoEncoders>));
+  exports.Set("SetVideoEncoder", Napi::Function::New(env, CatchNativeExceptions<ObsSetVideoEncoder>));
 
-  exports.Set("SetBuffering", Napi::Function::New(env, ObsSetBuffering));
-  exports.Set("SetFragmentation", Napi::Function::New(env, ObsSetFragmentation));
-  exports.Set("StartBuffer", Napi::Function::New(env, ObsStartBuffer));
-  exports.Set("StartRecording", Napi::Function::New(env, ObsStartRecording));
-  exports.Set("StopRecording", Napi::Function::New(env, ObsStopRecording));
-  exports.Set("ForceStopRecording", Napi::Function::New(env, ObsForceStopRecording));
-  exports.Set("GetLastRecording", Napi::Function::New(env, ObsGetLastRecording));
+  exports.Set("SetBuffering", Napi::Function::New(env, CatchNativeExceptions<ObsSetBuffering>));
+  exports.Set("SetFragmentation", Napi::Function::New(env, CatchNativeExceptions<ObsSetFragmentation>));
+  exports.Set("StartBuffer", Napi::Function::New(env, CatchNativeExceptions<ObsStartBuffer>));
+  exports.Set("StartRecording", Napi::Function::New(env, CatchNativeExceptions<ObsStartRecording>));
+  exports.Set("StopRecording", Napi::Function::New(env, CatchNativeExceptions<ObsStopRecording>));
+  exports.Set("ForceStopRecording", Napi::Function::New(env, CatchNativeExceptions<ObsForceStopRecording>));
+  exports.Set("GetLastRecording", Napi::Function::New(env, CatchNativeExceptions<ObsGetLastRecording>));
 
-  exports.Set("CreateSource", Napi::Function::New(env, ObsCreateSource));
-  exports.Set("DeleteSource", Napi::Function::New(env, ObsDeleteSource));
-  exports.Set("GetSourceSettings", Napi::Function::New(env, ObsGetSourceSettings));
-  exports.Set("SetSourceSettings", Napi::Function::New(env, ObsSetSourceSettings));
-  exports.Set("GetSourceProperties", Napi::Function::New(env, ObsGetSourceProperties));
-  exports.Set("SetMuteAudioInputs", Napi::Function::New(env, ObsSetMuteAudioInputs));
-  exports.Set("SetSourceVolume", Napi::Function::New(env, ObsSetSourceVolume));
-  exports.Set("SetVolmeterEnabled", Napi::Function::New(env, ObsSetVolmeterEnabled));
-  exports.Set("SetAudioSuppression", Napi::Function::New(env, ObsSetAudioSuppression));
-  exports.Set("SetForceMono", Napi::Function::New(env, ObsSetForceMono));
-  exports.Set("GetSourceAudioTracks", Napi::Function::New(env, ObsGetSourceAudioTracks));
-  exports.Set("SetSourceAudioTracks", Napi::Function::New(env, ObsSetSourceAudioTracks));
+  exports.Set("CreateSource", Napi::Function::New(env, CatchNativeExceptions<ObsCreateSource>));
+  exports.Set("DeleteSource", Napi::Function::New(env, CatchNativeExceptions<ObsDeleteSource>));
+  exports.Set("GetSourceSettings", Napi::Function::New(env, CatchNativeExceptions<ObsGetSourceSettings>));
+  exports.Set("SetSourceSettings", Napi::Function::New(env, CatchNativeExceptions<ObsSetSourceSettings>));
+  exports.Set("GetSourceProperties", Napi::Function::New(env, CatchNativeExceptions<ObsGetSourceProperties>));
+  exports.Set("SetMuteAudioInputs", Napi::Function::New(env, CatchNativeExceptions<ObsSetMuteAudioInputs>));
+  exports.Set("SetSourceVolume", Napi::Function::New(env, CatchNativeExceptions<ObsSetSourceVolume>));
+  exports.Set("SetVolmeterEnabled", Napi::Function::New(env, CatchNativeExceptions<ObsSetVolmeterEnabled>));
+  exports.Set("SetAudioSuppression", Napi::Function::New(env, CatchNativeExceptions<ObsSetAudioSuppression>));
+  exports.Set("SetForceMono", Napi::Function::New(env, CatchNativeExceptions<ObsSetForceMono>));
+  exports.Set("GetSourceAudioTracks", Napi::Function::New(env, CatchNativeExceptions<ObsGetSourceAudioTracks>));
+  exports.Set("SetSourceAudioTracks", Napi::Function::New(env, CatchNativeExceptions<ObsSetSourceAudioTracks>));
 
-  exports.Set("AddSourceToScene", Napi::Function::New(env, ObsAddSourceToScene));
-  exports.Set("RemoveSourceFromScene", Napi::Function::New(env, ObsRemoveSourceFromScene));
-  exports.Set("GetSourcePos", Napi::Function::New(env, ObsGetSourcePos));
-  exports.Set("SetSourcePos", Napi::Function::New(env, ObsSetSourcePos));
+  exports.Set("AddSourceToScene", Napi::Function::New(env, CatchNativeExceptions<ObsAddSourceToScene>));
+  exports.Set("RemoveSourceFromScene", Napi::Function::New(env, CatchNativeExceptions<ObsRemoveSourceFromScene>));
+  exports.Set("GetSourcePos", Napi::Function::New(env, CatchNativeExceptions<ObsGetSourcePos>));
+  exports.Set("SetSourcePos", Napi::Function::New(env, CatchNativeExceptions<ObsSetSourcePos>));
 
-  exports.Set("InitPreview", Napi::Function::New(env, ObsInitPreview));
-  exports.Set("ConfigurePreview", Napi::Function::New(env, ObsConfigurePreview));
-  exports.Set("ShowPreview", Napi::Function::New(env, ObsShowPreview));
-  exports.Set("HidePreview", Napi::Function::New(env, ObsHidePreview));
-  exports.Set("DisablePreview", Napi::Function::New(env, ObsDisablePreview));
-  exports.Set("GetPreviewInfo", Napi::Function::New(env, ObsGetPreviewInfo));
-  exports.Set("GetDrawSourceOutlineEnabled", Napi::Function::New(env, ObsGetDrawSourceOutlineEnabled));
-  exports.Set("SetDrawSourceOutline", Napi::Function::New(env, ObsSetDrawSourceOutline));
+  exports.Set("InitPreview", Napi::Function::New(env, CatchNativeExceptions<ObsInitPreview>));
+  exports.Set("ConfigurePreview", Napi::Function::New(env, CatchNativeExceptions<ObsConfigurePreview>));
+  exports.Set("ShowPreview", Napi::Function::New(env, CatchNativeExceptions<ObsShowPreview>));
+  exports.Set("HidePreview", Napi::Function::New(env, CatchNativeExceptions<ObsHidePreview>));
+  exports.Set("DisablePreview", Napi::Function::New(env, CatchNativeExceptions<ObsDisablePreview>));
+  exports.Set("GetPreviewInfo", Napi::Function::New(env, CatchNativeExceptions<ObsGetPreviewInfo>));
+  exports.Set("GetDrawSourceOutlineEnabled", Napi::Function::New(env, CatchNativeExceptions<ObsGetDrawSourceOutlineEnabled>));
+  exports.Set("SetDrawSourceOutline", Napi::Function::New(env, CatchNativeExceptions<ObsSetDrawSourceOutline>));
 
   return exports;
 }

--- a/src/obs_interface.cpp
+++ b/src/obs_interface.cpp
@@ -1077,7 +1077,7 @@ ObsInterface::~ObsInterface() {
 void ObsInterface::setBuffering(bool value) {
   if (obs_output_active(output)) {
     blog(LOG_ERROR, "Cannot change buffering state while output is active");
-    throw new std::runtime_error("Cannot change buffering state while output is active");
+    throw std::runtime_error("Cannot change buffering state while output is active");
   }
 
   buffering = value;
@@ -1087,7 +1087,7 @@ void ObsInterface::setBuffering(bool value) {
 void ObsInterface::setFragmentation(bool value) {
   if (obs_output_active(output)) {
     blog(LOG_ERROR, "Cannot change fragmentation state while output is active");
-    throw new std::runtime_error("Cannot change fragmentation state while output is active");
+    throw std::runtime_error("Cannot change fragmentation state while output is active");
   }
 
   fragmented = value;
@@ -1345,7 +1345,7 @@ std::vector<std::string> ObsInterface::listAvailableVideoEncoders()
 void ObsInterface::setVideoEncoder(std::string id, obs_data_t* settings) {
   if (obs_output_active(output)) {
     blog(LOG_WARNING, "Cannot change video encoder while output is active");
-    throw new std::runtime_error("Output is active when trying to change encoder");
+    throw std::runtime_error("Output is active when trying to change encoder");
   }
 
   video_encoder_id = id;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -420,7 +420,7 @@ void register_preview_window_class() {
 
 	if (RegisterClassEx(&klass) == NULL) {
 		blog(LOG_ERROR, "Failed to register window class");
-    throw new std::runtime_error("Failed to register window class");
+    throw std::runtime_error("Failed to register window class");
 	}
 
   blog(LOG_INFO, "Registered preview window class");


### PR DESCRIPTION
## Summary

- catch native exceptions at a shared boundary around every exported N-API callback
- translate `std::exception` messages into catchable JavaScript errors, with a fallback for unknown native failures
- throw the remaining pointer-allocated runtime errors by value and enable MSVC exception handling

## Motivation

PR #29 handled one missing-source failure explicitly, but other native exceptions could still escape an N-API callback and terminate the host process. This change applies the same protection consistently across the addon.

This does not replace explicit handling of expected failures such as PR #29. Expected conditions should still be translated locally at the binding boundary; the shared wrapper provides a last-resort boundary for remaining native exceptions.

This is defensive API hardening rather than a fix for a known Warcraft Recorder production issue. It mainly improves behavior for invalid call ordering, unexpected libobs failures, and other consumers of the library.

## Validation

- `npm run build` on Node.js 20.20.2 and 24.13.1
- `npm run test-errors`
- `npm run test-preview`
- before/after reproduction using `StartRecording()` without recording configuration
- verified the patched addon returns `Recording path is not set`, remains alive, and exits with code 0

No new regression test was added; the existing smoke checks and isolated reproduction were used for validation.
