### PR TITLE
Make Init() transactional and safe to reuse

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -19,5 +19,10 @@
             "<!(node -p \"require('node-addon-api').gyp\")"
         ],
         'defines': [ 'NAPI_DISABLE_CPP_EXCEPTIONS' ],
+        'msvs_settings': {
+            'VCCLCompilerTool': {
+                'ExceptionHandling': 1,
+            },
+        },
     }]
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,8 @@
 #include <napi.h>
 #include <windows.h>
 #include <obs.h>
+#include <exception>
+#include <memory>
 #include "obs_interface.h"
 #include "utils.h"
 
@@ -20,6 +22,11 @@ Napi::Value ObsInit(const Napi::CallbackInfo& info) {
     return info.Env().Undefined();
   }
 
+  if (obs) {
+    Napi::Error::New(info.Env(), "Obs is already initialized").ThrowAsJavaScriptException();
+    return info.Env().Undefined();
+  }
+
   std::string distPath = info[0].As<Napi::String>().Utf8Value();
   std::string logPath = info[1].As<Napi::String>().Utf8Value();
   Napi::Function fn = info[2].As<Napi::Function>();
@@ -27,7 +34,19 @@ Napi::Value ObsInit(const Napi::CallbackInfo& info) {
   Napi::ThreadSafeFunction jscb =
     Napi::ThreadSafeFunction::New(info.Env(), fn, "JavaScript callback", 0, 1);
 
-  obs = new ObsInterface(distPath, logPath, jscb);
+  std::unique_ptr<ObsInterface> candidate;
+
+  try {
+    candidate = std::make_unique<ObsInterface>(distPath, logPath, jscb);
+  } catch (const std::exception& error) {
+    Napi::Error::New(info.Env(), error.what()).ThrowAsJavaScriptException();
+    return info.Env().Undefined();
+  } catch (...) {
+    Napi::Error::New(info.Env(), "Unknown error while initializing OBS").ThrowAsJavaScriptException();
+    return info.Env().Undefined();
+  }
+
+  obs = candidate.release();
   return info.Env().Undefined();
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -700,6 +700,12 @@ Napi::Value ObsSetSourcePos(const Napi::CallbackInfo& info) {
 }
 
 Napi::Value ObsSetDrawSourceOutline(const Napi::CallbackInfo& info) {
+  if (!obs) {
+    blog(LOG_ERROR, "ObsSetDrawSourceOutline called but obs is not initialized");
+    Napi::Error::New(info.Env(), "Obs not initialized").ThrowAsJavaScriptException();
+    return info.Env().Undefined();
+  }
+
   bool valid =  info.Length() == 1 && info[0].IsBoolean();
     if (!valid) {
     Napi::TypeError::New(info.Env(), "Invalid arguments passed to ObsSetDrawSourceOutline").ThrowAsJavaScriptException();
@@ -712,6 +718,12 @@ Napi::Value ObsSetDrawSourceOutline(const Napi::CallbackInfo& info) {
 }
 
 Napi::Value ObsGetDrawSourceOutlineEnabled(const Napi::CallbackInfo& info) {
+  if (!obs) {
+    blog(LOG_ERROR, "ObsGetDrawSourceOutlineEnabled called but obs is not initialized");
+    Napi::Error::New(info.Env(), "Obs not initialized").ThrowAsJavaScriptException();
+    return info.Env().Undefined();
+  }
+
   return Napi::Boolean::New(info.Env(), obs->getDrawSourceOutlineEnabled());
 }
 

--- a/src/obs_interface.cpp
+++ b/src/obs_interface.cpp
@@ -491,13 +491,18 @@ std::string ObsInterface::createSource(std::string name, std::string type) {
 void ObsInterface::deleteSource(std::string name) {
   blog(LOG_INFO, "Delete source: %s", name.c_str());
 
+  auto ctx_it = volmeter_cb_ctx.find(name);
+  SignalContext* ctx = ctx_it != volmeter_cb_ctx.end() ? ctx_it->second : nullptr;
+
   // First release a volmeter if there is one present.
   // Only audio sources have volmeters ofcourse.
   auto vol_it = volmeters.find(name);
   
   if (vol_it != volmeters.end()) {
     obs_volmeter_t* volmeter = vol_it->second;
-    obs_volmeter_remove_callback(volmeter, volmeter_callback, this);
+    if (ctx) {
+      obs_volmeter_remove_callback(volmeter, volmeter_callback, ctx);
+    }
     obs_volmeter_detach_source(volmeter);
     obs_volmeter_destroy(volmeter);
     blog(LOG_INFO, "Volmeter deleted for source: %s", name.c_str());
@@ -505,10 +510,7 @@ void ObsInterface::deleteSource(std::string name) {
   }
 
   // Now deal with the callback context.
-  auto ctx_it = volmeter_cb_ctx.find(name);
-
   if (ctx_it != volmeter_cb_ctx.end()) {
-    SignalContext* ctx = ctx_it->second;
     delete ctx;
     volmeter_cb_ctx.erase(ctx_it);
   }
@@ -1026,7 +1028,12 @@ void ObsInterface::cleanup() noexcept {
 
   for (auto& kv : volmeters) {
     obs_volmeter_t* volmeter = kv.second;
-    obs_volmeter_remove_callback(volmeter, volmeter_callback, this);
+    auto ctx_it = volmeter_cb_ctx.find(kv.first);
+
+    if (ctx_it != volmeter_cb_ctx.end()) {
+      obs_volmeter_remove_callback(volmeter, volmeter_callback, ctx_it->second);
+    }
+
     obs_volmeter_detach_source(volmeter);
     obs_volmeter_destroy(volmeter);
     blog(LOG_INFO, "Volmeter deleted for source: %s", kv.first.c_str());

--- a/src/obs_interface.cpp
+++ b/src/obs_interface.cpp
@@ -168,6 +168,8 @@ void ObsInterface::init_obs(const std::string& distPath) {
     throw std::runtime_error("OBS startup failed");
   }
 
+  obs_started = true;
+
   if (!obs_initialized()) {
     blog(LOG_ERROR, "OBS not initialized!");
     throw std::runtime_error("OBS initialization failed");
@@ -966,35 +968,61 @@ ObsInterface::ObsInterface(
   const std::string& distPath, 
   const std::string& logPath, 
   Napi::ThreadSafeFunction cb
-) {
+) : log_path(logPath), jscb(cb) {
   // Setup logs first so we have logs for the initialization.
-  base_set_log_handler(log_handler, (void*)logPath.c_str());
+  base_set_log_handler(log_handler, (void*)log_path.c_str());
   blog(LOG_DEBUG, "Creating ObsInterface");
 
-  // Initialize OBS and load required modules.
-  init_obs(distPath);
+  try {
+    // Initialize OBS and load required modules.
+    init_obs(distPath);
 
-  // Setup callback function.
-  jscb = cb;
+    // Contexts for signal callbacks.
+    starting_ctx = new SignalContext{ this, "starting" };
+    start_ctx = new SignalContext{ this, "start" };
+    stopping_ctx = new SignalContext{ this, "stopping" };
+    stop_ctx = new SignalContext{ this, "stop" };
+    activate_ctx = new SignalContext{this, "activate"};
+    deactivate_ctx = new SignalContext{this, "deactivate"};
+    converted_ctx = new SignalContext{this, "converted"};
 
-  // Contexts for signal callbacks.
-  starting_ctx = new SignalContext{ this, "starting" };
-  start_ctx = new SignalContext{ this, "start" };
-  stopping_ctx = new SignalContext{ this, "stopping" };
-  stop_ctx = new SignalContext{ this, "stop" };
-  activate_ctx = new SignalContext{this, "activate"};
-  deactivate_ctx = new SignalContext{this, "deactivate"};
-  converted_ctx = new SignalContext{this, "converted"};
-
-  // Create the resources we rely on.
-  create_scene();
-  create_output();
-  create_video_encoders();
-  create_audio_encoders();
+    // Create the resources we rely on.
+    create_scene();
+    create_output();
+    create_video_encoders();
+    create_audio_encoders();
+  } catch (...) {
+    cleanup();
+    throw;
+  }
 }
 
 ObsInterface::~ObsInterface() {
+  cleanup();
+}
+
+void ObsInterface::cleanup() noexcept {
   blog(LOG_DEBUG, "Shutting down");
+
+  if (display) {
+    obs_display_remove_draw_callback(display, draw_callback, this);
+    obs_display_destroy(display);
+    display = nullptr;
+  }
+
+  if (preview_hwnd) {
+    DestroyWindow(preview_hwnd);
+    preview_hwnd = nullptr;
+  }
+
+  if (output) {
+    if (obs_output_active(output)) {
+      blog(LOG_DEBUG, "Force stopping output");
+      obs_output_force_stop(output);
+    }
+
+    disconnect_signal_handlers(output);
+  }
 
   for (auto& kv : volmeters) {
     obs_volmeter_t* volmeter = kv.second;
@@ -1002,25 +1030,17 @@ ObsInterface::~ObsInterface() {
     obs_volmeter_detach_source(volmeter);
     obs_volmeter_destroy(volmeter);
     blog(LOG_INFO, "Volmeter deleted for source: %s", kv.first.c_str());
-    volmeters.erase(kv.first);
   }
+  volmeters.clear();
 
   for (auto& kv : volmeter_cb_ctx) {
     SignalContext* ctx = kv.second;
     delete ctx;
-    volmeter_cb_ctx.erase(kv.first);
   }
-
-  delete starting_ctx;
-  delete start_ctx;
-  delete stopping_ctx;
-  delete stop_ctx;
-  delete activate_ctx;
-  delete deactivate_ctx;
-  delete converted_ctx;
+  volmeter_cb_ctx.clear();
 
   for (auto& kv : sources) {
-    std::string name = kv.first;
+    const std::string& name = kv.first;
     obs_source_t* source = kv.second;
 
     auto filter_it = filters.find(name);
@@ -1029,42 +1049,73 @@ ObsInterface::~ObsInterface() {
       obs_source_t* filter = filter_it->second;
       obs_source_filter_remove(source, filter);
       obs_source_release(filter);
-      filters.erase(name);
+      filters.erase(filter_it);
       blog(LOG_INFO, "Filter removed for source: %s on shutdown", name.c_str());
     }
 
     blog(LOG_DEBUG, "Releasing source: %s", name.c_str());
     obs_source_release(source);
-    sources.erase(name);
   }
+  sources.clear();
+  sizes.clear();
+
+  for (auto& kv : filters) {
+    obs_source_release(kv.second);
+  }
+  filters.clear();
 
   if (scene) {
     blog(LOG_DEBUG, "Releasing scene");
+    obs_set_output_source(0, nullptr);
     obs_scene_release(scene);
+    scene = nullptr;
   }
 
   if (output) {
-    if (obs_output_active(output)) {
-      blog(LOG_DEBUG, "Force stopping output");
-      obs_output_force_stop(output);
-    }
-      
     blog(LOG_DEBUG, "Releasing output");
     obs_output_release(output);
+    output = nullptr;
   }
 
-  // if (video_encoder) {
-  //   blog(LOG_DEBUG, "Releasing video encoder");
-  //   obs_encoder_release(video_encoder);
-  // }
+  if (video_encoder) {
+    blog(LOG_DEBUG, "Releasing video encoder");
+    obs_encoder_release(video_encoder);
+    video_encoder = nullptr;
+  }
 
-  // if (audio_encoder) {
-  //   blog(LOG_DEBUG, "Releasing audio encoder");
-  //   obs_encoder_release(audio_encoder);
-  // }
+  for (int i = 0; i < MAX_AUDIO_MIXES; i++) {
+    if (audio_encoders[i]) {
+      blog(LOG_DEBUG, "Releasing audio encoder: %d", i);
+      obs_encoder_release(audio_encoders[i]);
+      audio_encoders[i] = nullptr;
+    }
+  }
 
-  blog(LOG_DEBUG, "Now shutting down OBS");
-  obs_shutdown();
+  if (video_encoder_settings) {
+    obs_data_release(video_encoder_settings);
+    video_encoder_settings = nullptr;
+  }
+
+  delete starting_ctx;
+  starting_ctx = nullptr;
+  delete start_ctx;
+  start_ctx = nullptr;
+  delete stopping_ctx;
+  stopping_ctx = nullptr;
+  delete stop_ctx;
+  stop_ctx = nullptr;
+  delete activate_ctx;
+  activate_ctx = nullptr;
+  delete deactivate_ctx;
+  deactivate_ctx = nullptr;
+  delete converted_ctx;
+  converted_ctx = nullptr;
+
+  if (obs_started) {
+    blog(LOG_DEBUG, "Now shutting down OBS");
+    obs_shutdown();
+    obs_started = false;
+  }
 
   if (jscb) {
     blog(LOG_DEBUG, "Releasing JavaScript callback");

--- a/src/obs_interface.h
+++ b/src/obs_interface.h
@@ -106,6 +106,7 @@ class ObsInterface {
     
     obs_display_t *display = nullptr;
     HWND preview_hwnd = nullptr; // window handle for scene preview
+    std::string log_path;
     Napi::ThreadSafeFunction jscb; // javascript callback
     std::string recording_path = ""; 
     std::string unbuffered_output_filename = "";
@@ -114,20 +115,22 @@ class ObsInterface {
     bool buffering = false; // Whether we are buffering the recording in memory.
     bool fragmented = false; // Use fragmented MP4.
     bool drawSourceOutline = false; // Draw red outline around source
+    bool obs_started = false; // Whether this instance owns a successful obs_startup call.
     void init_obs(const std::string& distPath);
+    void cleanup() noexcept;
     int reset_video(int fps, int width, int height);
     bool reset_audio();
     void load_module(const char* module, const char* data, bool allowFail); // Load a module, data is optional.
     void connect_signal_handlers(obs_output_t *output);
     void disconnect_signal_handlers(obs_output_t *output);
 
-    SignalContext* starting_ctx;
-    SignalContext* start_ctx;
-    SignalContext* stopping_ctx;
-    SignalContext* stop_ctx;
-    SignalContext* activate_ctx;
-    SignalContext* deactivate_ctx;
-    SignalContext* converted_ctx;
+    SignalContext* starting_ctx = nullptr;
+    SignalContext* start_ctx = nullptr;
+    SignalContext* stopping_ctx = nullptr;
+    SignalContext* stop_ctx = nullptr;
+    SignalContext* activate_ctx = nullptr;
+    SignalContext* deactivate_ctx = nullptr;
+    SignalContext* converted_ctx = nullptr;
     static void output_signal_handler(void *data, calldata_t *cd);
 
     void list_encoders(obs_encoder_type type = OBS_ENCODER_VIDEO);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -418,10 +418,17 @@ void register_preview_window_class() {
 	klass.lpszClassName = TEXT("PreviewWindowClass");
 	klass.hIconSm = NULL;
 
-	if (RegisterClassEx(&klass) == NULL) {
-		blog(LOG_ERROR, "Failed to register window class");
-    throw new std::runtime_error("Failed to register window class");
-	}
+  if (RegisterClassEx(&klass) == NULL) {
+    DWORD error = GetLastError();
+
+    if (error != ERROR_CLASS_ALREADY_EXISTS) {
+      blog(LOG_ERROR, "Failed to register window class. Error: %lu", error);
+      throw std::runtime_error("Failed to register window class");
+    }
+
+    blog(LOG_DEBUG, "Preview window class is already registered");
+    return;
+  }
 
   blog(LOG_INFO, "Registered preview window class");
 }


### PR DESCRIPTION
## Summary

- construct `ObsInterface` transactionally and publish the global instance only after initialization succeeds
- clean up partially initialized libobs resources so `Init()` can be retried after a failure or `Shutdown()`
- reject duplicate `Init()` calls without replacing the active instance
- make preview window-class registration safe across repeated initialization cycles

## Root cause

Initialization could leave libobs and native resources active when construction failed, while another `Init()` could replace the global instance. Cleanup also erased container entries while iterating and did not release all owned resources. Together, these lifecycle issues made retries and repeated use unsafe.

## Impact

Initialization failures are now surfaced as JavaScript errors, failed attempts roll back their native state, the active instance survives a duplicate call, and callers can initialize again after shutdown.

## Validation

- `npm run build`
- `npm run test-errors`
- `npm run test-preview`
- manual `Init()` -> `Shutdown()` -> `Init()` cycle
- manual duplicate `Init()` check, including verification that the original instance remains active
- manual failed `Init()` followed by a successful retry
- manual repeated `Shutdown()` and preview lifecycle checks
- verified on Node.js 20 and Node.js 24.13.1

No regression test file is included; the lifecycle scenarios above were exercised locally with temporary scripts.
